### PR TITLE
Move coveralls to the top to pick up all app code.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,7 @@
+# This needs to go before all requires to be able to record full coverage
+require 'coveralls'
+Coveralls.wear!
+# Now the application requires.
 require 'hawkular'
 require 'metrics/metrics_client'
 require 'inventory/inventory_api'
@@ -8,9 +12,6 @@ require 'rspec/mocks'
 require 'socket'
 require 'uri'
 require 'yaml'
-require 'coveralls'
-
-Coveralls.wear!
 
 module Hawkular::Metrics::RSpec
   def setup_client(options = {})


### PR DESCRIPTION
The coverall definition needs to be before requiring any app code.
