### PR TITLE
- Add list-events support in alerts-api

### DIFF
--- a/spec/integration/alerts_spec.rb
+++ b/spec/integration/alerts_spec.rb
@@ -140,4 +140,44 @@ module Hawkular::Alerts::RSpec
   #     expect(data).not_to be_nil
   #   end
   # end
+
+  describe 'Alert/Events', :vcr do
+
+    VCR.configure do |c|
+      c.default_cassette_options = {
+        :match_requests_on => [:method, VCR.request_matchers.uri_without_params(:startTime, :endTime)]
+      }
+    end
+
+    it 'Should list events' do
+      client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds)
+
+      events = client.list_events
+
+      expect(events).to_not be_nil
+      expect(events.size).to be(12)
+    end
+
+    it 'Should list events using criteria' do
+      now = Time.new.to_i
+      startTime = (now - 7_200) * 1000
+      endTime = now * 1000
+
+      client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds)
+
+      events = client.list_events('startTime' => startTime, 'endTime' => endTime)
+
+      expect(events).to_not be_nil
+      expect(events.size).to be(1)
+    end
+
+    it 'Should not list events using criteria' do
+      client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds)
+
+      events = client.list_events('startTime' => 0, 'endTime' => 1000)
+
+      expect(events).to_not be_nil
+      expect(events.size).to be(0)
+    end
+  end
 end

--- a/spec/vcr_cassettes/Alert/Events/Should_list_events.yml
+++ b/spec/vcr_cassettes/Alert/Events/Should_list_events.yml
@@ -1,0 +1,168 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/events
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 03 Mar 2016 17:12:02 GMT
+      X-Total-Count:
+      - '12'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '5134'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/events>; rel="current", <http://localhost:8080/hawkular/alerts/events?page=0>;
+        rel="last"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO1dC3PaSNb9Kyqqpma3KnL6/fBUtsrjkMTf2nEKyMzO2i6X
+        kITDDgYv4CT+puLfvrclwICRABswj5unUdNSP865fbv73NbZX4X4a9zsVu5u
+        4sJ+4eC4WKoUXhW6cTNodo8iuMQMYarKlW9qsfAF58w3IjS+ZCKmmgfKVGuQ
+        o+6++3tcvSzHnU691ewchN361/gyDGlV1ETNr1lifaGCyA+E0n411FHMOQ2U
+        Iq+PW2HQ8KmQUsH9DRVa+oZGhimmfcIVPLcWhb6JDfVJNTJUchuoKoPnwlOu
+        oeQjeV8VoqAblFu37dBV6rLZasaXhfTq0bPL6R4adOOrVvtupMW+d93H5G4e
+        PMDrP8CrtdreWZL1wuVtNdPv/lUIGnF70PKHlaPfipflYrl8dPqxDF9sx52k
+        Bh8DV8HCXAXs5/0UdL9A3tfdX2bpxte1X2Z6SvuX5Dn390NP6lfj5gYq3v4a
+        t12btOtXV3G7l1QKmldx4QdcDq46rvr9rEmXzFG9H4M7u7u8BFThJs20V0Y6
+        Or2PA1rcCdv1my5cnQkT3bSFToonvxZL8HkSJZNrhwPgNW8bjf4XEzilFzpw
+        pV3v3iV3e3v0+QQRtxjEBbfd1tt6J6g24M7d9m2cXio2x6+U4BkNQMF+LWh0
+        Rq8duNbvTPjySdANvyR9fTwwUyfBjSvy7/VG9K5x5x1cXbXjK+j+KAHSSQxV
+        DTv3Q5cnwMyh4Oi+dH82e13v7y/uTyr3z3sstNd1fF2N26e1iVRzcE4aLuo3
+        Rq3erjevRtuhM2bAf7imub6Jm/DNpzG/B4+FjAG9e520IlfEd0elo4/vH6hc
+        rpSODiuXlaOTYsLdoFGBepbjbjcpPOlda3WDxqOLMKANrglG4NdQxWeurv+8
+        wbhXoR9pmaA8AKazs78GJex0oUT9cRfKw63tjbuPU7U1RJpB25QOPr4vpnYp
+        qqc2cr0781GBoTnK9f93bsfoxaNmFH8fvbra/vKpT0ct/m2z7vySTp+aMwxO
+        KdF6rtKL2I9XhdZN3A66rfZx6xsU4ujj4fHnMoxWQykf6ldfxpK6X8DAf2k1
+        oiQXI3tk6Fr6fQlscpfrzXRwSK00VBhgfQsfIfHHxatsnCtBDM3CuZGWaY44
+        R5xvOs4to0yqLJxbaglDnCPONx/nhnLCMnGuLeEacY4433Ccc6Itl1n+OQfn
+        XQmGOEecbzrOKaE802+BVEIUzkMR55uPcwU4t5k4V4QwizhHnG86zhmjXGXa
+        c8YIZeifI843H+cwD9WZ/jmkEiYR54jzzcD5xfA+dG9fuht0b91+5Omn4kd4
+        VBD+WUmEGyT5+dfBF9vpjmg0SO1f6H/lx6uFSlb+77eTy/eHc8pUNKFWKqOt
+        8VkQSRVFxI+siHxBFGTUofBtNbKxMJEJwuqITOUh71SZytxlmyJNCW+vbxsJ
+        aN4fem9vAQaAFu9T3PZP6s3bbjybUuX9QenXgy1UC1T6SF8bjcpT+r+nS4Gs
+        XkaHTzBhcwJjKXKVD0fvPyDoNl2mchJfQ38/jFMZEHz2uDjjc0aFKCmf1kF8
+        8hRmr0ZwwsmTBSfzD6Wzi0zcqMkU3Gbi5nsvlXAy5HNWFuwjL77Pxsu4FLf4
+        qb2S6QpfP3aCxyi3KOd3RpLDA+vtOOyVBRzaUvGgnDY0+Lr1VlqSj58rw+6v
+        K3Vl2Od1Dq/zXgeuLBWMpc7uTTv+Wm/ddn7rJXBrdOocDzt1fQD2v10ZSSSQ
+        qGBkgNLDkzgne+6f/l+RNTl0eaFfuRVZuOdMEMkR94j7ReFeGi71JNwPCDGC
+        +z4AJ+O+R4oU91RRSfYMMUZC3YVVKhf3BqZJEzfn01RJJNp7xP3CcK+YZHIS
+        7geEGMV9D4ATcd8nRYp7QazdM5prJZjhwtg82AuhiSFZsBdCUYuwR9gvDvaK
+        THZzBnwYgX0fgJNh3+NECnsuKLg5RBEjnMJEaZ6He0kJ0xP3epJUYjijiHvE
+        /cJwb4kwE3HfJ8Tomm0PgBNx3ydFz723gu8JaajWRGuhZD7uwcsxOhP3ClBg
+        EPeI+0XhXhNlJuO+T4jxvYoEgBNx3ydF3713+YW2SkstrKVss/aC3sY3jdbd
+        Ndzv8l1Qb9y25w1fhibRTElmrK9oXKOxpT6nEfOFINoPTBj7MKcJVUx5YEw8
+        vi/Uyzt1X+hZ5czdI3q4s1dL7zzbntDb4qfj0z9Oih8rl+8Ojo43f6Hee2iJ
+        R2v2RYe4tdkkei4YehtGQz3fu80jczgVHC+wL4TA27CNorR6UN9GPUzGOchy
+        02p25uury+zbjG75PGbHOmz/PJezs2wFTdoFopN2geiEXaCnbQA9b/ycazMo
+        GSp51uIgpHJLHiIair+BgRg1IidxpxM4AUvhsHXbiLxmq+uBDwUG7do7Syty
+        4bWaXuCdDaHswruqAwm96p1Xbzo2OkfuBqyFd7YsY3HhteP/3kL9wD2E8pwx
+        QpVPOPypULlP6L8v9hOLDcndlhclJffOupDB79SvbxqxT/fAAdz7FrQvzpt0
+        3/tP8DXYawTNq73i9zBOjPu+d174/d3xH4eVY8Io2wcnNK1y7PVNjHf2t/Pz
+        80I06GL3yXvzD8/9P/FpLuHvF+cFaPfDAFgE92ss27D+WOjUaLk0HQLlEudJ
+        i+Dk4zlTpmPQN7LD06WFmHWwCt9hCpII3Nw9ex6E9+aN9/OH4NufMIEaHjt/
+        fuW5sibJxVLptPRz4WEKNDpp6PfDE/0v+KRpzAkQMorA0Zfct1G16qtARpFm
+        NRoJPsHRT+3TFEd/QS035O9PaKoH7z9pKDSTO2Amf2zYxLx8+anVahy2Y2jr
+        OezX/evObbVzB6C4fuNIlfZR57X72U8/vPlnfBc2WsGfb8v9A8h4so6dTNer
+        EqbsWsaxLyiUshoa7UtuWFwlokqraoTYD3mnz+BXUqHcqb57vpcWwHP96PUM
+        hiMukD6Z2r0t92Z38z03b6Gg7JaxkiWrJ0/U5m6EFU3rBj/9xN5NLCFcn1rG
+        fjs94GeZksE5m3IxCxarwn5/ZWPwXW8c84+WOJZMihc55w0pt+GUe7GlmjHi
+        DDYsAHrgE6Y8cULx1A2Yf1tkPv64LZT5ijS2FDRsd9ZiFWhVhnDtj6pbkX83
+        55l2lhCTFWPNDCSrh5i8yodSsfzh9PjtYjdn1wQiE2u3nOWKVSJhnr3gTAvz
+        9F3hZZu/eXaFoW+mnQjGmZyoUuifF2YZsgHZsCNsUDLv3DDJiDXIBmTDjrDB
+        ABsmBqikqZwoimxANuwEGzihwAaTedYe5UkgGLIB2bATbDCUy6yxAUYNQQSO
+        DciGnWEDz2ODlkQQZAOyYTfYQInmmWtKkKoIFcgGZMOOsIEDGzLnDZQrMnTW
+        JbIB2bDdbFA694RjRQl6SsiGXWGD1VxlzhuoxbEB2bA7bGDM5p4KrolANiAb
+        doUN0nKdOTYwqYffYYVsQDZsNxts/kn6BtmAbNgZNrhwJJ25psSpGT4yF9mA
+        bNgCNmxYYONhq9lcekijYtIQ4uua4ZaL2K8qTn1hqPENjaRvwkDGYSB0LQ4L
+        4yGNad5ZQhqXWpVC7rstvgb1hgvn8FwZ0kOz4Mdbd1TNsuIYTz86KGFI1SaG
+        VC0kinHZcH8cvzgJ5pPM/LLIsJT4xcPSUeXo8OAYybalZFu/+MUHfgApXtrt
+        GS3Mo5hFx+HCekQrLtvgbUKc4nLdtbkiFGfYFaKr0Fa+LCxWOq9bRe9nzujC
+        Gcf8nhlZj0ndaLFGpnPHUw6qtc/eBUL0I/o3Ff3qubs+jCP6Ef1bin5jp+3y
+        rGJdG9GP6H8B9E/f1aGriD5H9CP6l4F+PQX9WurJ78dKUoUlbBXn8iD6Ef0v
+        YfsNzUO/IavRtyD6Ef0vgH5BAf08C/2CEkJWcQoVoh/RvwT0MzIF/QLQn7nm
+        IwTB9X5E//aiX9OM9yT2UlcTLY7oR/S/wG6XBL8+8zRaSGWE43o/on9T0T/F
+        75dcaps565XuWDVc70f0byr6zRT0K0B/5qxXKnD8LaIf0b+h6J/m+VhAf+Ze
+        r7QCbT+if2vRrxigP3PWq5iALkX0I/o3FP0KI/ZcUxe/B+6tkEMBe9S6gL1q
+        VIuICJgfchH4gkXUDxQnvg5FTcqalWGU4Gg0YC/J+0IBe4OaFFYVrzd44ouH
+        6w3XfU0DiCYVcf3ihx5KucaxesNNuQ6heiM82OpIPeTZMni2m2F6D6zBKL2Z
+        CLejQXoPHtq8MXqSu7ffTJ6/QSohG7pnPzsoNn36Nt73GzF7e5phW+SGPWMy
+        N0APoY/Q31boS4B+5qodpCL0EfpbCn2jc0PzFEIfob+d0OfQLTrT6kMqQh+h
+        v6XQB+TnBeXpjQ3MQOgj9KdA3+ZBH9LQ6iP0txL6ggD0WWZIBjFkJS9pQugj
+        9FcOfW7zYvE4Wn2E/rZCXwH0M1d4hELoI/S3FfrW5kThCYvQR+hvKfQls9pm
+        ChkkQ+gj9LcV+tLmxd9JhD5Cf1uhbwD6mdNcSEXoI/S3E/qKAvQz5WuQitBH
+        6G8y9Dcp7O7w0+fLz53gasb3Kd40gm6t1b6+fw0VKR1UoOsvy3+UK8WTN7Pk
+        vzxNmrLevConXfX6U+n0sFgun5be8H6EnqTcUBehFzIZ1YgfGqF9UVXcD0xs
+        fRlGnMVGUFIThfEIvTTv1Ai99al0IS+YD4rpnfELLynqKLuGY4OS2pQP3hcv
+        i/86LBadSXlKlNBya7nscKJB6X9i7xZT/iXcE+4zuVV6Pfmp3QKb1QFLkx3A
+        NJICGeAJ3TvaQ0uKlGfFOC0TBgsJOlwr8vbiEx/afnyMG+fwC8UPoo1AG7Ex
+        NuKlAiYfWmcu/3OJrZE4qiOdNhQdOTCEhTWIj1wrq7z2oZTr01pzRl0S685F
+        y5q7EwtNsvQ3pKxP463RNH99GmXaisBPE32kgYF7ygrA6izwyGLA+7HFALLH
+        HpYCyJ6lhkhqheFKcWFl3poYle7EtcxoZgm8WvoZzOsDIeQV8iqPV5pzriS3
+        ggplbG7QHHXfzAyao5yQpZ/uvD4QQl4hr/J4paR78y8n0IOG5vNK87xgVM1x
+        vEJeIa96vJJGMWGYIlorw3NjnpJXjWXGPMEUiyz9HXzrAyHkFfIql1dUM8GF
+        0EYIkTtecZsbRmtxvEJeIa/6vBKWS0IpU8oymzteCcnzQlYk8gp5hbwa8Ipa
+        Iiz0E6Ek3w+UlOcFBVDkFfIKedXnFRdUMeZe00m00CjAe1IXsHEBXk1ZGdSY
+        r0LGfVGTyrc1qv1YiJgLuKnVeuMFeGy6AI9tvgCPobhmgrhmuFV2QlzDtkyA
+        x2YW4DEU4KGNQBsxq41AAV6/NVCA9yRDggK82b3uhQvwdkfQMB1qO7gwwLZq
+        YWDcAs8pwONSCsOkMTRZGEABHvIKefV8XmmlteGUWUYFyxW2ogAPeYW8mlmA
+        Z+G3cNs7VnLzTAEe8gp5hbxKecWUhdmiJdyCP/hMAR76gcgr5FUqwFPcKMM0
+        sRqmSM8U4OF4hbxCXqW8EsRoSaURiuXPr1CAh7xCXs0swFNaKqE1E4oY+kwB
+        Ho5XyCvkVSrAs4oKa60hzpVDAd6TuoCOCfA41YGxVeHHUcCgErH1Ax0KnxHD
+        dQS3rHGy8QI8Ol2ARzdfgEdRXDNBXDPcKjshrqFbJsCjMwvwKArw0EagjZjV
+        RqAAr98aKMB7kiFBAd7sXjcK8JYItR1cGKBbtTAwboHn3HgViiZhr9JQlhvx
+        OoMAD3mFvEJepRtEWinFlNbUTjn5ZAYBHkNeIa+QVwmviABGSKMZ1SRf2OoE
+        eJkv8NoxAR7yCnmVv/HKqeGCScMNk+KZAjzkFfIKeZVuvCpFlTbajTgUBXjI
+        K+TVYnglBFNSaUGFNbnj1QwCPOQV8gp5lfCKKUupMEIyZvLHKxTgIa+QV7Py
+        ilrFuDuu1bHDogDvSV1AegI8S4iAeapfIzUdKqH9gDO4Ha8RP5Ai9MMoDJki
+        VV5TZlyA18u7OQI8Ml2ARzZfgEdQXDNBXDPcKjshriFbJsAjMwvwCArw0Eag
+        jZjVRqAAr98aKMB7kiFBAd7sXvdcAjwjDRXMZCwMGKkt02pnFgamQ20HFwbI
+        Vi0MjFvgeRYGwDxIQQk3hmhlgDg5K25GCcZUlqIBUskuhZIjsZBY+cTShBNN
+        teFMUJN3tqTRhCVj0mRiaQIE3R0JHhILiTWFWBxYRa2FwUjnHoJntHLbSJnE
+        Ujt1aCsSC4k1bcRi3L21h1pjWa4raBgQKysYw6UisZBYSKw+sZThhLnDJa2R
+        eaJx46hjMz1BSEVeIa+QV4MBS2lr3PIFUZrleoJWME5YFrHc2a9ILCQWEqtP
+        LEnciMWkIJKrHGIlchaiM4gFqZwQicRCYiGxUmIxAS4gsVpQJld9EF7xt+LH
+        Z+jw4JOmMSc+4VHkCyG5b6Nq1VeBjCLNajQSfETupgnVzFmB6XK3mXr1uBUG
+        jcu38U2jdXdwc9Ooh4EDTCnu3LSanXhUqPYh+PbnbSNoe+n3r6EZHmRrxVLp
+        tDQKxpO409tXP2zdNiKv2ep60LMORd5Zeo8Lr9X0Au9s6NkX3lUdWtir3nn1
+        pmtqeLh3E3S/eGcL14Yk1b+/v/Da8X9vwdDGkSvPGSNUQZfAnwqV+4T++2Lf
+        exfUG5DcbXlRUnLvrAsZ/E79+qYR+3SPwO9vQfvivEn3vf8EX4O9RtC82it+
+        D+OEg/veeeH3d8d/HFaOCaNs33t7m1Y59vpSDO/sb+fn54Vo0Lruk/fmH577
+        f+LTXMLfL84L0O6HASAA7tdYlo6m11aFHwvmAGMxYyYO/Ciqal+EVPo2CKwv
+        azzQVMURDJgjHFBWUusWVdaOA6f/zCLApxT2AKCZgH+0KuCvFjgX/wOnt6y5
+        o5cBAA==
+    http_version: 
+  recorded_at: Thu, 03 Mar 2016 17:12:02 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Alert/Events/Should_list_events_using_criteria.yml
+++ b/spec/vcr_cassettes/Alert/Events/Should_list_events_using_criteria.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/events?endTime=1457025122000&startTime=1457017922000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 03 Mar 2016 17:12:02 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1096'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/events?startTime=1457017922000&endTime=1457025122000>;
+        rel="current", <http://localhost:8080/hawkular/alerts/events?startTime=1457017922000&endTime=1457025122000&page=0>;
+        rel="last"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO2ZX0/jOBDAv0rVZ1Kc2LGd5al0u2xPlEVtb++hqpCbuBBd
+        mlSOg5ZD7We/cf4dYVMEHLe6hyBByYzHnhn/xh7C8rEv72WsFw872f/UH16O
+        Z4v+SV/LWMR6EoDI4ciha0wtvpHEIhg7Fic+t1yHSJthQfl6AxahGfvb9+nN
+        xejG9+012ZCNtfGQZxEqAksQyqy1zwKJsS0oRaeXiS8iyyYuQ7bnUs48bjki
+        cGkQICvwSGARRMGQ+cTy1oEnCQ+48Newlq/DLXjbsD3pB0KLeZIp3wRyEyex
+        vOkX0sm7fDMLCS1vE/XQyMwPbR59P9tmEeiD3sWo9zlTQodJ3LuWypqGcaZl
+        b5Oo3jKfaWWmSuLC9LEvIqmqhF8MZ+dDUCuZ5q5fCRNZ/01eVrbXQt+B7ak+
+        e82enW7OXrWKOsvXORyerFTRstv15lLdS2USo8LbW6lK1eIOxt4lUdDfg0rc
+        pibwyjzfjzeEuK9nN7P8KjbBMC52A0x7RzbcECZTX4W7/OkdYOgiYdPx9Hw8
+        g+e2csxloxrGOIuiamDOVCFIQaJCbWj9Orn42kH3b6ETmU4+h6lYRzC7Vpks
+        ROP4uWQGa0T3INqIKG3KhibvacvgqdD+Xb7Hl/UxNRU74/IfYRR8iR56U7mF
+        /YYPCNNPD8cQBHgmh9lh+frgDofVYbo4vHEdyMhWbtdSfdvU9WTgzNMRVCFu
+        QhXGt83o0mfH8t4EvN3JGEa+r6TLjX/3yV7aT5PAuPVlMptcXfxTjPPFbDJa
+        3Cwm03FefSJaQGxzqXXuMCpliRbRT0K4mmoZRubrSbCvDtF6+1VaBrEv/AAf
+        gLrl8rH2KtXgRX1rOhSmsQvwWrUIozofs+FiXBwnQVgg9//bs+c+QgLm4V+m
+        TWgKJ3EgfzSl//2uWLZlN8/jLA5NH7FNf7pBnpVc3cD8miKHBUMl/dKXydVo
+        Nh7Oi0Tv4HZJCk+ufs+TnYBI6EQZr/PmqD6APzkIDRC4D/Blea/m5BKYRcn7
+        MMnS76UCe5zlikZTVwFYjV40lAiUFG4G8B5WwhgNzI/qm+xXJ0e5h33FHjnG
+        PXYIcnHHfcf9R3HvcuyyNu7rgmhwXwHYzn1ZFAX3NrVdNOCIcxdiJx6lL3LP
+        4c8k5yj33EVud9533H8Y99RxHbeN+7ogmtyXALZyXxVFwT1BnjfgDDNKHI4J
+        917CnhCGODqGPSHU9jrsO+w/DnuK2tucuh4a2FcAtmNf1kSBPSY2tDmIIk6w
+        Z5p3/BL3ro0cRo9x7yKOHbvjvuP+w7j3EOGt3FcF0XxnWwLYyn1VFGV77xE8
+        IC63GUOMEeq+zD10OZwd5Z4CBbzjvuP+o7hniPJ27quCeP6/ihzAVu6roqja
+        e2NPmEeZy4jn2c5+tXr6krd86auFzlLw9Nv1+Ap8Ff6fxaQo//28HqiK145B
+        ra0E1ZD96m+PwUj3DRoAAA==
+    http_version: 
+  recorded_at: Thu, 03 Mar 2016 17:12:02 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Alert/Events/Should_not_list_events_using_criteria.yml
+++ b/spec/vcr_cassettes/Alert/Events/Should_not_list_events_using_criteria.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/events?endTime=1000&startTime=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 03 Mar 2016 17:12:02 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '22'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAIuOBQApu0wNAgAAAA==
+    http_version: 
+  recorded_at: Thu, 03 Mar 2016 17:12:02 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
- Add to the spec
  - note, see mechanism for ignoring parts of the uri in the vcr match
- refactor generate_query_params
  - not really necessary, mainly a ruby exercise for me
