### PR TITLE
- Add list-events support in alerts-api

### DIFF
--- a/lib/alerts/alerts_api.rb
+++ b/lib/alerts/alerts_api.rb
@@ -2,8 +2,10 @@ require 'hawkular'
 require 'ostruct'
 
 # Alerts module provides access to Hawkular-Alerts.
-# There are two main parts here: Triggers, that define alertable conditions
-# and Alerts that represent a fired trigger.
+# There are three main parts here:
+#   Triggers, that define alertable conditions
+#     Alerts, that represent a fired Alert trigger
+#     Events, that represent a fired Event trigger or an externally injected event (hawkular, not miq event)
 # @see http://www.hawkular.org/docs/rest/rest-alerts.html
 module Hawkular::Alerts
   # Interface to use to talk to the Hawkular-Alerts component.
@@ -67,9 +69,11 @@ module Hawkular::Alerts
     end
 
     # List fired alerts
+    # @param [Hash]criteria optional query criteria
     # @return [Array<Alert>] List of alerts in the system. Can be empty
-    def list_alerts
-      ret = http_get('/')
+    def list_alerts(criteria = {})
+      query = generate_query_params(criteria)
+      ret = http_get('/' + query)
       val = []
       ret.each { |a| val.push(Alert.new(a)) }
       val
@@ -108,6 +112,21 @@ module Hawkular::Alerts
       http_put(sub_url, {})
 
       true
+    end
+
+    # List Events given optional criteria. Criteria keys are strings (not symbols):
+    #  startTime   numeric, milliseconds from epoch
+    #  endTime     numeric, milliseconds from epoch
+    #  eventIds    array of strings
+    #  triggerIds  array of strings
+    #  categories  array of strings
+    #  tags        array of strings, each tag of format 'name|value'. Specify '*' for value to match all values
+    #  thin        boolean, return lighter events (omits triggering data for trigger-generated events)
+    # @param [Hash] criteria optional query criteria
+    # @return [Array<Event>] List of events. Can be empty
+    def list_events(*criteria)
+      query = generate_query_params(*criteria)
+      http_get('/events' + query).map { |e| Event.new(e) }
     end
   end
 
@@ -183,11 +202,21 @@ module Hawkular::Alerts
 
   # Representation of one alert.
   # The name of the members are literally what they are in the JSON sent from the
-  # server and not 'rubyfied'. So 'alertId' and not 'alert_ic'
+  # server and not 'rubyfied'. So 'alertId' and not 'alert_id'
   # Check http://www.hawkular.org/docs/rest/rest-alerts.html#Alert for details
   class Alert < OpenStruct
     def initialize(alert_hash)
       super(alert_hash)
+    end
+  end
+
+  # Representation of one event.
+  # The name of the members are literally what they are in the JSON sent from the
+  # server and not 'rubyfied'. So 'eventId' and not 'event_id'
+  # Check http://www.hawkular.org/docs/rest/rest-alerts.html#Event for details
+  class Event < OpenStruct
+    def initialize(event_hash)
+      super(event_hash)
     end
   end
 end

--- a/spec/integration/alerts_spec.rb
+++ b/spec/integration/alerts_spec.rb
@@ -140,4 +140,43 @@ module Hawkular::Alerts::RSpec
   #     expect(data).not_to be_nil
   #   end
   # end
+
+  describe 'Alert/Events', :vcr do
+    VCR.configure do |c|
+      c.default_cassette_options = {
+        match_requests_on: [:method, VCR.request_matchers.uri_without_params(:startTime, :endTime)]
+      }
+    end
+
+    it 'Should list events' do
+      client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds)
+
+      events = client.list_events('thin' => true)
+
+      expect(events).to_not be_nil
+      expect(events.size).to be(12)
+    end
+
+    it 'Should list events using criteria' do
+      now = Time.new.to_i
+      start_time = (now - 7_200) * 1000
+      end_time = now * 1000
+
+      client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds)
+
+      events = client.list_events('startTime' => start_time, 'endTime' => end_time)
+
+      expect(events).to_not be_nil
+      expect(events.size).to be(1)
+    end
+
+    it 'Should not list events using criteria' do
+      client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds)
+
+      events = client.list_events('startTime' => 0, 'endTime' => 1000)
+
+      expect(events).to_not be_nil
+      expect(events.size).to be(0)
+    end
+  end
 end

--- a/spec/vcr_cassettes/Alert/Events/Should_list_events.yml
+++ b/spec/vcr_cassettes/Alert/Events/Should_list_events.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/events?thin=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 03 Mar 2016 20:57:01 GMT
+      X-Total-Count:
+      - '12'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2138'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/events?thin=true>; rel="current", <http://localhost:8080/hawkular/alerts/events?thin=true&page=0>;
+        rel="last"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO1cDW/aShb9KxbSk3alTjMzHn+lykqUOCnbECKg7XYJQmPP
+        mPJqbNY2eY2ewm/fGZtvSIAmJJBYjVQ8+M7ce+fce44dx82/C/yGB0njts8L
+        x4XihV1rFN4VEh7QICkzMYRNiHVH1YHpcQKIqmJgEtcEGiYcGSrVTccTFl15
+        7jfutOs8jrthEBfdpHvD266LHOIRD3gWtADRKQOU6AZwXINxVUVU1+HRRehS
+        HyCiabqY30TE0ICJmIl1bACo6mJdj7nA5CYC0GEm0lSL6g4W64pVesLzOdt3
+        BUYTWg8HkSuDagdhwNuFbLT8aD/lojThnTC6ncvYr0QeprMpYgFlvIDihZHS
+        TE1b0jYMsnP/LlCfR5PMlxrlr3a7btfr5eplXZwY8TiN4JLKAAtbOTi2vaLJ
+        D2F7lHzYZBuPvA8brRJ9SNcZDmdWGofR74vAoxseyZxE3U6HR6OvajTo8MKd
+        GKadWIY/Nk23ZIvw7iYzy1leAqpikiDblbmNzuaRQOOxG3X7iRjdCBNJlqGK
+        Xflo18TxqpJMx0oT4AUD3x+fmMIpG4jFSNRNbtPZTstfKjningZxdJCEp92Y
+        Or6YOYkGPBuyg8WRmljDFyg49qgfz48VZfbjFSdXaOL+SPf6YtKmKrQvXf7W
+        9dmZf6sUO52Id8T2sxRIFS5CdePhzPAKmEkUlIe1YXPzWIfD1rDSGD5uWZGv
+        Hu85PKp6K0tNwjlNHBsnw+tG3aAzn4d4oYHfzcJ7BPeEJgMZZvXKvhQm1P3Z
+        SPkApp8/Tk6MskSzybfjgfEpd++elAn//bXSPi9tyX4GRJamm4ZlAkyZpjMG
+        AbMIAwTqwtBwCbAcZnFiMpO6zhz7TW3Xst/Wvq1hPHfQG/gpFs5LyukgorLv
+        KVc8ApVuMEj4ZgR4Xqx9LL7CJtT4Ic79Efpsb6jvd/Z/RHfCVLlnw1fQ3pbA
+        2AkLfiqff8pBd+jsV+E9sd9T+rkHgo+muw3Xmee3rJ5eP6ed8r4f3vbEfO0z
+        2vUH0bZXd4KjDKxr2LSAjriHuIWAihgGhEADUNPlwNRNV+dIpabJF/ltZLuW
+        3x7l54NcN51Z8bKZN+O2U/vqovq9Yl822mfF8sXhNxxlmoml3mNLxO0N2T0W
+        DCPim9n50TRLfLcWHC/AbznwDozwsvBEvH7XTblGmPTFddN2e9W+f5p56lqu
+        jjdAY/X2VRj6pYiLMtuiGQyP4oET38YJ753IPctyEB/JzyA7OPnMb10/pD9P
+        6+O7mSqyVFNLyc3RBMEZGueAIOGl45oG0FQTcwcSBzn60t3MzHY93z1LQA8S
+        o1xfyRxQ5D4qI7yJa/1AXPmnjfC0PuqF2637EK3WSzW72LAf09a2TsIzNcHJ
+        pz/w2UoPxfhaH8d5muJnlxcKW6byaej9ubA/1gGTc5VFzC8Jgh0XxYvcNM5L
+        7sBL7sWEzULhTC6xBfRoh2d1Im8PZTJg+wv57epHXvRv59KCcJrtO29CM5XC
+        INi5WtKxZkIIDM9ULZVw4OgqAsREpvx1sAZMl2rcpcTwuLukljLbTdTSTkN5
+        +Gb5jVDZEimK9IG7KbxK4UBeM+5KIlUvL/NufaDd+kkE0q7hviyNVsE8Xv4F
+        wc6KYSfSqFQrN8ql4kVebK+02PZPGk3rQxTFS4uieWeW5JCs4VwI/d4e2L9o
+        r+/zGR2ELKmDHOYxSCgGrkooIJghQHVV6COXeJrmWZrL0LIOSm1fSAdNInk2
+        GTRZ8cVV0Gzse9qXV7m4f2156uUeS6DZVO6DApqrg1ctgPI620WdvU31M62a
+        XPysbaSlqy/tLzHtbHijve/TRLSx3vBIBFIrNsqX5+3693rDrpxsYt+u9rl8
+        3ibo1NM9PLqqVUt2vV6tnahjnaQh1URSJ7lYYx4ErkkMQBxdBdTkFhD6SMXc
+        JAh6ZEknZbZrddL+BP2gpBJuKk21paSu3t+h02jqxXO7bf+nZNunv9mrdxvl
+        rpv6xHvRtZ/G/x3MKeZZnZXRTl5FoWhmcfjQw39z3wgDsUJyi0ZoyZDyKKbZ
+        JQyeRPrtVfGOVOI094tycLGGX0jF5T0i7xEH0yNeSrZOs7OVMN1hNlIFO7dp
+        Mxp10ghzlfpsO4IXVaqnWxr1MNBdrALiaTqwPGQATghXiZjUMoyDV6l4vUrF
+        h69Scc5AKxgIvzUGwq9MpeKNVSrOVWreI/IesWmPyFXqOBu5St2zno8WVKqK
+        DGpaDgGcUSyC4Fb2l+cYmqrBxJSeCg9epaL1KhUdvkpFOQOtYCD01hgIvTKV
+        ijZWqShXqXmPyHvEpj0iV6njbOQqdc96PhypVAtCopoYeNAzXJ0YgKpYTKd6
+        EFCNuMBlrot16Kiebi6q1JHt4ahUuF6lwsNXqTBnoBUMBN8aA8FXplLhxioV
+        5io17xF5j9i0R+QqdZyNV6NS7a/25SNUqjgyEFchgCpjgBBNBRZzHKBTjTED
+        e4gRtbD8MjEhCNeLwSd56c6cjPtE//o58Oniq4wyUWfXatXafKOuiHrOUFcK
+        Bz5TgjBRBCYkppRmNkdLCQOFKs2ZtVtKR75nQnFulW4gUy3fa9cXrVNp7uoh
+        +ZYS8f8NeCzflif8aWKIdLEl4qeBtGOI/ts6Tl+eJb5OQoWlnivNRBiAuCuf
+        wgboPRT//qJR6zpAx8qf9Ia+92nQeW//cnnKmcfKdeHb2cX3UuMCYoSPldNB
+        FjJXxo1Kaf7j+vq6wCbZlUfKyb8U+f/K1eQX/2xdF0TeS1QgQMzn7/odV3dP
+        XAMYc4xNTgFjjgGIizRgUWoBzVOpgXTOCNTmakC3NGTJR072rgaqn+8rgKsM
+        9gJAGwG//FzAf17gtP4PsfDxTbVfAAA=
+    http_version: 
+  recorded_at: Thu, 03 Mar 2016 20:57:01 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Alert/Events/Should_list_events_using_criteria.yml
+++ b/spec/vcr_cassettes/Alert/Events/Should_list_events_using_criteria.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/events?endTime=1457025122000&startTime=1457017922000
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 03 Mar 2016 17:12:02 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '1096'
+      Link:
+      - <http://localhost:8080/hawkular/alerts/events?startTime=1457017922000&endTime=1457025122000>;
+        rel="current", <http://localhost:8080/hawkular/alerts/events?startTime=1457017922000&endTime=1457025122000&page=0>;
+        rel="last"
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAO2ZX0/jOBDAv0rVZ1Kc2LGd5al0u2xPlEVtb++hqpCbuBBd
+        mlSOg5ZD7We/cf4dYVMEHLe6hyBByYzHnhn/xh7C8rEv72WsFw872f/UH16O
+        Z4v+SV/LWMR6EoDI4ciha0wtvpHEIhg7Fic+t1yHSJthQfl6AxahGfvb9+nN
+        xejG9+012ZCNtfGQZxEqAksQyqy1zwKJsS0oRaeXiS8iyyYuQ7bnUs48bjki
+        cGkQICvwSGARRMGQ+cTy1oEnCQ+48Newlq/DLXjbsD3pB0KLeZIp3wRyEyex
+        vOkX0sm7fDMLCS1vE/XQyMwPbR59P9tmEeiD3sWo9zlTQodJ3LuWypqGcaZl
+        b5Oo3jKfaWWmSuLC9LEvIqmqhF8MZ+dDUCuZ5q5fCRNZ/01eVrbXQt+B7ak+
+        e82enW7OXrWKOsvXORyerFTRstv15lLdS2USo8LbW6lK1eIOxt4lUdDfg0rc
+        pibwyjzfjzeEuK9nN7P8KjbBMC52A0x7RzbcECZTX4W7/OkdYOgiYdPx9Hw8
+        g+e2csxloxrGOIuiamDOVCFIQaJCbWj9Orn42kH3b6ETmU4+h6lYRzC7Vpks
+        ROP4uWQGa0T3INqIKG3KhibvacvgqdD+Xb7Hl/UxNRU74/IfYRR8iR56U7mF
+        /YYPCNNPD8cQBHgmh9lh+frgDofVYbo4vHEdyMhWbtdSfdvU9WTgzNMRVCFu
+        QhXGt83o0mfH8t4EvN3JGEa+r6TLjX/3yV7aT5PAuPVlMptcXfxTjPPFbDJa
+        3Cwm03FefSJaQGxzqXXuMCpliRbRT0K4mmoZRubrSbCvDtF6+1VaBrEv/AAf
+        gLrl8rH2KtXgRX1rOhSmsQvwWrUIozofs+FiXBwnQVgg9//bs+c+QgLm4V+m
+        TWgKJ3EgfzSl//2uWLZlN8/jLA5NH7FNf7pBnpVc3cD8miKHBUMl/dKXydVo
+        Nh7Oi0Tv4HZJCk+ufs+TnYBI6EQZr/PmqD6APzkIDRC4D/Blea/m5BKYRcn7
+        MMnS76UCe5zlikZTVwFYjV40lAiUFG4G8B5WwhgNzI/qm+xXJ0e5h33FHjnG
+        PXYIcnHHfcf9R3HvcuyyNu7rgmhwXwHYzn1ZFAX3NrVdNOCIcxdiJx6lL3LP
+        4c8k5yj33EVud9533H8Y99RxHbeN+7ogmtyXALZyXxVFwT1BnjfgDDNKHI4J
+        917CnhCGODqGPSHU9jrsO+w/DnuK2tucuh4a2FcAtmNf1kSBPSY2tDmIIk6w
+        Z5p3/BL3ro0cRo9x7yKOHbvjvuP+w7j3EOGt3FcF0XxnWwLYyn1VFGV77xE8
+        IC63GUOMEeq+zD10OZwd5Z4CBbzjvuP+o7hniPJ27quCeP6/ihzAVu6roqja
+        e2NPmEeZy4jn2c5+tXr6krd86auFzlLw9Nv1+Ap8Ff6fxaQo//28HqiK145B
+        ra0E1ZD96m+PwUj3DRoAAA==
+    http_version: 
+  recorded_at: Thu, 03 Mar 2016 17:12:02 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Alert/Events/Should_not_list_events_using_criteria.yml
+++ b/spec/vcr_cassettes/Alert/Events/Should_not_list_events_using_criteria.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/events?endTime=1000&startTime=0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Encoding:
+      - gzip
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 03 Mar 2016 17:12:02 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '22'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAIuOBQApu0wNAgAAAA==
+    http_version: 
+  recorded_at: Thu, 03 Mar 2016 17:12:02 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
- Add to the spec
  - note, see mechanism for ignoring parts of the uri in the vcr match
- refactor generate_query_params
  - not really necessary, mainly a ruby exercise for me
