### PR TITLE
Resource hierarchy fixes

### DIFF
--- a/lib/hawkular/base_client.rb
+++ b/lib/hawkular/base_client.rb
@@ -44,6 +44,7 @@ module Hawkular
     # as many ids inside Hawkular can contain characters
     # that are invalid for an url/uri.
     # The passed value is duplicated
+    # Does not escape the = character
     # @param [String] url_part Part of an url to be escaped
     # @return [String] escaped url_part as new string
     def hawk_escape(url_part)
@@ -62,6 +63,19 @@ module Hawkular
       sub_url.gsub!('(', '%28')
       sub_url.gsub!(')', '%29')
       sub_url.gsub!('/', '%2f')
+      sub_url
+    end
+
+    # Escapes the passed url part. This is necessary,
+    # as many ids inside Hawkular can contain characters
+    # that are invalid for an url/uri.
+    # The passed value is duplicated
+    # Does escape the = character
+    # @param [String] url_part Part of an url to be escaped
+    # @return [String] escaped url_part as new string
+    def hawk_escape_id(url_part)
+      sub_url = hawk_escape url_part
+      sub_url.gsub!('=', '%3d')
       sub_url
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'rspec/mocks'
 require 'socket'
 require 'uri'
 require 'yaml'
+require 'json'
 
 module Hawkular::Metrics::RSpec
   def setup_client(options = {})

--- a/spec/vcr_cassettes/Inventory/Helpers/create_url.yml
+++ b/spec/vcr_cassettes/Inventory/Helpers/create_url.yml
@@ -1,24 +1,26 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/api/urls
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: '{"url":"http://bsd.de"}'
     headers:
       Accept:
-      - application/json
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       Content-Type:
       - application/json
+      Content-Length:
+      - '23'
       User-Agent:
       - Ruby
   response:
     status:
-      code: 200
-      message: OK
+      code: 201
+      message: Created
     headers:
       Expires:
       - '0'
@@ -30,25 +32,17 @@ http_interactions:
       - WildFly/10
       Pragma:
       - no-cache
+      Location:
+      - http://127.0.0.1:8080/hawkular/inventory/test/resources/536cc3ede5769b60a49774425aedba24
       Date:
       - Thu, 05 May 2016 11:18:36 GMT
-      X-Total-Count:
-      - '1'
       Connection:
       - keep-alive
-      Content-Type:
-      - application/json
       Content-Length:
-      - '148'
-      Link:
-      - <http://localhost:8080/hawkular/inventory/feeds>; rel="current"
+      - '0'
     body:
-      encoding: ASCII-8BIT
-      string: |-
-        [ {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;5958668a-b073-4098-b265-587b45c659ee",
-          "id" : "5958668a-b073-4098-b265-587b45c659ee"
-        } ]
+      encoding: UTF-8
+      string: ''
     http_version: 
   recorded_at: Thu, 05 May 2016 11:18:36 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Helpers/generate_some_events_for_websocket.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Helpers/generate_some_events_for_websocket.yml
@@ -35,7 +35,7 @@ http_interactions:
       Location:
       - http://localhost:8080/hawkular/inventory/feeds/<%= uuid_prefix %>-feed
       Date:
-      - Mon, 11 Apr 2016 16:51:45 GMT
+      - Thu, 05 May 2016 11:18:48 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -50,7 +50,7 @@ http_interactions:
           "id" : "<%= uuid_prefix %>-feed"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:45 GMT
+  recorded_at: Thu, 05 May 2016 11:18:48 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= uuid_prefix %>-feed/resourceTypes
@@ -86,7 +86,7 @@ http_interactions:
       Location:
       - http://localhost:8080/hawkular/inventory/feeds/<%= uuid_prefix %>-feed/resourceTypes/<%= uuid_prefix %>-rt-123
       Date:
-      - Mon, 11 Apr 2016 16:51:45 GMT
+      - Thu, 05 May 2016 11:18:48 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -102,7 +102,7 @@ http_interactions:
           "id" : "<%= uuid_prefix %>-rt-123"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:45 GMT
+  recorded_at: Thu, 05 May 2016 11:18:48 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= uuid_prefix %>-feed/resourceTypes/<%= uuid_prefix %>-rt-123
@@ -134,7 +134,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:45 GMT
+      - Thu, 05 May 2016 11:18:48 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -150,7 +150,7 @@ http_interactions:
           "id" : "<%= uuid_prefix %>-rt-123"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:45 GMT
+  recorded_at: Thu, 05 May 2016 11:18:48 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= uuid_prefix %>-feed/resources
@@ -187,7 +187,7 @@ http_interactions:
       Location:
       - http://localhost:8080/hawkular/inventory/feeds/<%= uuid_prefix %>-feed/resources/<%= uuid_prefix %>-r126
       Date:
-      - Mon, 11 Apr 2016 16:51:45 GMT
+      - Thu, 05 May 2016 11:18:48 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -211,7 +211,7 @@ http_interactions:
           "id" : "<%= uuid_prefix %>-r126"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:45 GMT
+  recorded_at: Thu, 05 May 2016 11:18:48 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= uuid_prefix %>-feed/resources/<%= uuid_prefix %>-r126
@@ -243,7 +243,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:45 GMT
+      - Thu, 05 May 2016 11:18:49 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -267,7 +267,7 @@ http_interactions:
           "id" : "<%= uuid_prefix %>-r126"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:45 GMT
+  recorded_at: Thu, 05 May 2016 11:18:49 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= uuid_prefix %>-feed/resources
@@ -304,7 +304,7 @@ http_interactions:
       Location:
       - http://localhost:8080/hawkular/inventory/feeds/<%= uuid_prefix %>-feed/resources/<%= uuid_prefix %>-r127
       Date:
-      - Mon, 11 Apr 2016 16:51:45 GMT
+      - Thu, 05 May 2016 11:18:49 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -328,7 +328,7 @@ http_interactions:
           "id" : "<%= uuid_prefix %>-r127"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:45 GMT
+  recorded_at: Thu, 05 May 2016 11:18:49 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= uuid_prefix %>-feed/resources/<%= uuid_prefix %>-r127
@@ -360,7 +360,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:45 GMT
+      - Thu, 05 May 2016 11:18:49 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -384,7 +384,7 @@ http_interactions:
           "id" : "<%= uuid_prefix %>-r127"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:45 GMT
+  recorded_at: Thu, 05 May 2016 11:18:49 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= uuid_prefix %>-feed/resources
@@ -421,7 +421,7 @@ http_interactions:
       Location:
       - http://localhost:8080/hawkular/inventory/feeds/<%= uuid_prefix %>-feed/resources/<%= uuid_prefix %>-r128
       Date:
-      - Mon, 11 Apr 2016 16:51:45 GMT
+      - Thu, 05 May 2016 11:18:49 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -445,7 +445,7 @@ http_interactions:
           "id" : "<%= uuid_prefix %>-r128"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:45 GMT
+  recorded_at: Thu, 05 May 2016 11:18:49 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= uuid_prefix %>-feed/resources/<%= uuid_prefix %>-r128
@@ -477,7 +477,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:45 GMT
+      - Thu, 05 May 2016 11:18:49 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -501,7 +501,7 @@ http_interactions:
           "id" : "<%= uuid_prefix %>-r128"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:45 GMT
+  recorded_at: Thu, 05 May 2016 11:18:49 GMT
 - request:
     method: delete
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= uuid_prefix %>-feed
@@ -533,10 +533,10 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:46 GMT
+      - Thu, 05 May 2016 11:18:49 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:46 GMT
+  recorded_at: Thu, 05 May 2016 11:18:49 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_List_datasources_with_no_props.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_List_datasources_with_no_props.yml
@@ -31,7 +31,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:39 GMT
+      - Thu, 05 May 2016 11:18:41 GMT
       X-Total-Count:
       - '2'
       Connection:
@@ -66,7 +66,7 @@ http_interactions:
           "id" : "Local~/subsystem=datasources/data-source=KeycloakDS"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:39 GMT
+  recorded_at: Thu, 05 May 2016 11:18:41 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~%2Fsubsystem=datasources%2Fdata-source=ExampleDS/data?dataType=configuration
@@ -98,7 +98,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:39 GMT
+      - Thu, 05 May 2016 11:18:41 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -118,7 +118,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:39 GMT
+  recorded_at: Thu, 05 May 2016 11:18:41 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~%2Fsubsystem=datasources%2Fdata-source=KeycloakDS/data?dataType=configuration
@@ -150,7 +150,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:39 GMT
+      - Thu, 05 May 2016 11:18:41 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -170,5 +170,5 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:39 GMT
+  recorded_at: Thu, 05 May 2016 11:18:41 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_create_a_feed.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_create_a_feed.yml
@@ -35,7 +35,7 @@ http_interactions:
       Location:
       - http://localhost:8080/hawkular/inventory/feeds/feed_1123sdncisud6237ui23hjbdscuzsad
       Date:
-      - Mon, 11 Apr 2016 16:51:42 GMT
+      - Thu, 05 May 2016 11:18:45 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -50,5 +50,5 @@ http_interactions:
           "id" : "feed_1123sdncisud6237ui23hjbdscuzsad"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:42 GMT
+  recorded_at: Thu, 05 May 2016 11:18:45 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_create_a_feed_again.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_create_a_feed_again.yml
@@ -35,7 +35,7 @@ http_interactions:
       Location:
       - http://localhost:8080/hawkular/inventory/feeds/feed_1123sdncisud6237ui2378789vvgX
       Date:
-      - Mon, 11 Apr 2016 16:51:42 GMT
+      - Thu, 05 May 2016 11:18:45 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -50,7 +50,7 @@ http_interactions:
           "id" : "feed_1123sdncisud6237ui2378789vvgX"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:42 GMT
+  recorded_at: Thu, 05 May 2016 11:18:45 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/
@@ -84,7 +84,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:42 GMT
+      - Thu, 05 May 2016 11:18:45 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -113,7 +113,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:42 GMT
+  recorded_at: Thu, 05 May 2016 11:18:45 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_1123sdncisud6237ui2378789vvgX
@@ -145,7 +145,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:42 GMT
+      - Thu, 05 May 2016 11:18:45 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -160,5 +160,5 @@ http_interactions:
           "id" : "feed_1123sdncisud6237ui2378789vvgX"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:42 GMT
+  recorded_at: Thu, 05 May 2016 11:18:45 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_create_a_nested_resource_and_metric_on_it.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_create_a_nested_resource_and_metric_on_it.yml
@@ -33,7 +33,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 05 May 2016 11:18:46 GMT
+      - Thu, 05 May 2016 11:18:47 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -62,7 +62,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:46 GMT
+  recorded_at: Thu, 05 May 2016 11:18:47 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist
@@ -94,7 +94,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 05 May 2016 11:18:46 GMT
+      - Thu, 05 May 2016 11:18:47 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -109,13 +109,13 @@ http_interactions:
           "id" : "feed_may_exist"
         }
     http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:46 GMT
+  recorded_at: Thu, 05 May 2016 11:18:47 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resourceTypes
     body:
       encoding: UTF-8
-      string: '{"properties":{},"id":"rt-123","name":"ResourceType","outgoing":{},"incoming":{}}'
+      string: '{"properties":{},"id":"rt-123-1","name":"ResourceType","outgoing":{},"incoming":{}}'
     headers:
       Accept:
       - application/json
@@ -124,13 +124,13 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '81'
+      - '83'
       User-Agent:
       - Ruby
   response:
     status:
-      code: 409
-      message: Conflict
+      code: 201
+      message: Created
     headers:
       Expires:
       - '0'
@@ -142,26 +142,29 @@ http_interactions:
       - WildFly/10
       Pragma:
       - no-cache
+      Location:
+      - http://localhost:8080/hawkular/inventory/feeds/feed_may_exist/resourceTypes/rt-123-1
       Date:
-      - Thu, 05 May 2016 11:18:46 GMT
+      - Thu, 05 May 2016 11:18:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '107'
+      - '133'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "errorMsg" : "Entity with id 'null' already exists at some of the positions: null",
-          "details" : { }
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/rt;rt-123-1",
+          "name" : "ResourceType",
+          "id" : "rt-123-1"
         }
     http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:46 GMT
+  recorded_at: Thu, 05 May 2016 11:18:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resourceTypes/rt-123
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resourceTypes/rt-123-1
     body:
       encoding: US-ASCII
       string: ''
@@ -190,29 +193,29 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 05 May 2016 11:18:46 GMT
+      - Thu, 05 May 2016 11:18:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '129'
+      - '133'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/rt;rt-123",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/rt;rt-123-1",
           "name" : "ResourceType",
-          "id" : "rt-123"
+          "id" : "rt-123-1"
         }
     http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:46 GMT
+  recorded_at: Thu, 05 May 2016 11:18:47 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources
     body:
       encoding: UTF-8
-      string: '{"properties":{"version":1.0},"id":"r124","name":"My Resource","outgoing":{},"incoming":{},"resourceTypePath":"/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/rt;rt-123"}'
+      string: '{"properties":{},"id":"r124-a","name":"Res-a","outgoing":{},"incoming":{},"resourceTypePath":"/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/rt;rt-123-1"}'
     headers:
       Accept:
       - application/json
@@ -221,7 +224,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '179'
+      - '164'
       User-Agent:
       - Ruby
   response:
@@ -240,36 +243,33 @@ http_interactions:
       Pragma:
       - no-cache
       Location:
-      - http://localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r124
+      - http://localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r124-a
       Date:
-      - Thu, 05 May 2016 11:18:46 GMT
+      - Thu, 05 May 2016 11:18:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '317'
+      - '275'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/r;r124",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/r;r124-a",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/rt;rt-123",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/rt;rt-123-1",
             "name" : "ResourceType",
-            "id" : "rt-123"
+            "id" : "rt-123-1"
           },
-          "properties" : {
-            "version" : 1.0
-          },
-          "name" : "My Resource",
-          "id" : "r124"
+          "name" : "Res-a",
+          "id" : "r124-a"
         }
     http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:46 GMT
+  recorded_at: Thu, 05 May 2016 11:18:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r124
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r124-a
     body:
       encoding: US-ASCII
       string: ''
@@ -298,34 +298,88 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 05 May 2016 11:18:46 GMT
+      - Thu, 05 May 2016 11:18:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '317'
+      - '275'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/r;r124",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/r;r124-a",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/rt;rt-123",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/rt;rt-123-1",
             "name" : "ResourceType",
-            "id" : "rt-123"
+            "id" : "rt-123-1"
           },
-          "properties" : {
-            "version" : 1.0
-          },
-          "name" : "My Resource",
-          "id" : "r124"
+          "name" : "Res-a",
+          "id" : "r124-a"
         }
     http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:46 GMT
+  recorded_at: Thu, 05 May 2016 11:18:47 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r124-a
+    body:
+      encoding: UTF-8
+      string: '{"properties":{},"id":"r124-b","name":"Res-a","outgoing":{},"incoming":{},"resourceTypePath":"/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/rt;rt-123-1"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '164'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r124-a/r124-b
+      Date:
+      - Thu, 05 May 2016 11:18:47 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '284'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/r;r124-a/r;r124-b",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/rt;rt-123-1",
+            "name" : "ResourceType",
+            "id" : "rt-123-1"
+          },
+          "name" : "Res-a",
+          "id" : "r124-b"
+        }
+    http_version: 
+  recorded_at: Thu, 05 May 2016 11:18:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r124
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r124-a/r124-b
     body:
       encoding: US-ASCII
       string: ''
@@ -354,37 +408,34 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 05 May 2016 11:18:46 GMT
+      - Thu, 05 May 2016 11:18:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '317'
+      - '284'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/r;r124",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/r;r124-a/r;r124-b",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/rt;rt-123",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/rt;rt-123-1",
             "name" : "ResourceType",
-            "id" : "rt-123"
+            "id" : "rt-123-1"
           },
-          "properties" : {
-            "version" : 1.0
-          },
-          "name" : "My Resource",
-          "id" : "r124"
+          "name" : "Res-a",
+          "id" : "r124-b"
         }
     http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:46 GMT
+  recorded_at: Thu, 05 May 2016 11:18:47 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/metricTypes
     body:
       encoding: UTF-8
-      string: '{"id":"mt-124","type":"GAUGE","unit":"NONE","collectionInterval":60}'
+      string: '{"id":"mt-124-a","type":"GAUGE","unit":"NONE","collectionInterval":60}'
     headers:
       Accept:
       - application/json
@@ -393,7 +444,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '68'
+      - '70'
       User-Agent:
       - Ruby
   response:
@@ -412,30 +463,30 @@ http_interactions:
       Pragma:
       - no-cache
       Location:
-      - http://localhost:8080/hawkular/inventory/feeds/feed_may_exist/metricTypes/mt-124
+      - http://localhost:8080/hawkular/inventory/feeds/feed_may_exist/metricTypes/mt-124-a
       Date:
-      - Thu, 05 May 2016 11:18:46 GMT
+      - Thu, 05 May 2016 11:18:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '170'
+      - '174'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/mt;mt-124",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/mt;mt-124-a",
           "unit" : "NONE",
           "type" : "GAUGE",
           "collectionInterval" : 60,
-          "id" : "mt-124"
+          "id" : "mt-124-a"
         }
     http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:46 GMT
+  recorded_at: Thu, 05 May 2016 11:18:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/metricTypes/mt-124
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/metricTypes/mt-124-a
     body:
       encoding: US-ASCII
       string: ''
@@ -464,31 +515,31 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 05 May 2016 11:18:46 GMT
+      - Thu, 05 May 2016 11:18:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '170'
+      - '174'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/mt;mt-124",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/mt;mt-124-a",
           "unit" : "NONE",
           "type" : "GAUGE",
           "collectionInterval" : 60,
-          "id" : "mt-124"
+          "id" : "mt-124-a"
         }
     http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:46 GMT
+  recorded_at: Thu, 05 May 2016 11:18:47 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/metrics
     body:
       encoding: UTF-8
-      string: '{"id":"m-124","name":"m-124","metricTypePath":"/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/mt;mt-124"}'
+      string: '{"id":"m-124-a","name":"MetricUnderNestedResource","metricTypePath":"/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/mt;mt-124-a"}'
     headers:
       Accept:
       - application/json
@@ -497,7 +548,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '115'
+      - '139'
       User-Agent:
       - Ruby
   response:
@@ -516,35 +567,35 @@ http_interactions:
       Pragma:
       - no-cache
       Location:
-      - http://localhost:8080/hawkular/inventory/feeds/feed_may_exist/metrics/m-124
+      - http://localhost:8080/hawkular/inventory/feeds/feed_may_exist/metrics/m-124-a
       Date:
-      - Thu, 05 May 2016 11:18:46 GMT
+      - Thu, 05 May 2016 11:18:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '314'
+      - '342'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/m;m-124",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/m;m-124-a",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/mt;mt-124",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/mt;mt-124-a",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 60,
-            "id" : "mt-124"
+            "id" : "mt-124-a"
           },
-          "name" : "m-124",
-          "id" : "m-124"
+          "name" : "MetricUnderNestedResource",
+          "id" : "m-124-a"
         }
     http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:46 GMT
+  recorded_at: Thu, 05 May 2016 11:18:47 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/metrics/m-124
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/metrics/m-124-a
     body:
       encoding: US-ASCII
       string: ''
@@ -573,189 +624,36 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 05 May 2016 11:18:46 GMT
+      - Thu, 05 May 2016 11:18:47 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '314'
+      - '342'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/m;m-124",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/m;m-124-a",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/mt;mt-124",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/mt;mt-124-a",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 60,
-            "id" : "mt-124"
+            "id" : "mt-124-a"
           },
-          "name" : "m-124",
-          "id" : "m-124"
+          "name" : "MetricUnderNestedResource",
+          "id" : "m-124-a"
         }
     http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:46 GMT
+  recorded_at: Thu, 05 May 2016 11:18:47 GMT
 - request:
     method: post
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r124/metrics
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r124-a/r124-b/metrics
     body:
       encoding: UTF-8
-      string: '["/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/m;m-124"]'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '68'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 204
-      message: No Content
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Thu, 05 May 2016 11:18:46 GMT
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:46 GMT
-- request:
-    method: post
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/metrics
-    body:
-      encoding: UTF-8
-      string: '{"id":"m-124-1","name":"Metric1","metricTypePath":"/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/mt;mt-124"}'
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '119'
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Location:
-      - http://localhost:8080/hawkular/inventory/feeds/feed_may_exist/metrics/m-124-1
-      Date:
-      - Thu, 05 May 2016 11:18:46 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '320'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/m;m-124-1",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/mt;mt-124",
-            "unit" : "NONE",
-            "type" : "GAUGE",
-            "collectionInterval" : 60,
-            "id" : "mt-124"
-          },
-          "name" : "Metric1",
-          "id" : "m-124-1"
-        }
-    http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:46 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/metrics/m-124-1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Thu, 05 May 2016 11:18:46 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '320'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/m;m-124-1",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/mt;mt-124",
-            "unit" : "NONE",
-            "type" : "GAUGE",
-            "collectionInterval" : 60,
-            "id" : "mt-124"
-          },
-          "name" : "Metric1",
-          "id" : "m-124-1"
-        }
-    http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:46 GMT
-- request:
-    method: post
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r124/metrics
-    body:
-      encoding: UTF-8
-      string: '["/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/m;m-124-1"]'
+      string: '["/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/m;m-124-a"]'
     headers:
       Accept:
       - application/json
@@ -789,4 +687,64 @@ http_interactions:
       string: ''
     http_version: 
   recorded_at: Thu, 05 May 2016 11:18:47 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r124-a/r124-b/metrics?sort=id
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 05 May 2016 11:18:48 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '346'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r124-a/r124-b/metrics?sort=id>;
+        rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/m;m-124-a",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;feed_may_exist/mt;mt-124-a",
+            "unit" : "NONE",
+            "type" : "GAUGE",
+            "collectionInterval" : 60,
+            "id" : "mt-124-a"
+          },
+          "name" : "MetricUnderNestedResource",
+          "id" : "m-124-a"
+        } ]
+    http_version: 
+  recorded_at: Thu, 05 May 2016 11:18:48 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_create_a_resource.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_create_a_resource.yml
@@ -33,7 +33,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:43 GMT
+      - Thu, 05 May 2016 11:18:45 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -62,7 +62,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:43 GMT
+  recorded_at: Thu, 05 May 2016 11:18:45 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist
@@ -94,7 +94,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:43 GMT
+      - Thu, 05 May 2016 11:18:45 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -109,7 +109,7 @@ http_interactions:
           "id" : "feed_may_exist"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:43 GMT
+  recorded_at: Thu, 05 May 2016 11:18:45 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resourceTypes
@@ -143,7 +143,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:43 GMT
+      - Thu, 05 May 2016 11:18:45 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -158,7 +158,7 @@ http_interactions:
           "details" : { }
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:43 GMT
+  recorded_at: Thu, 05 May 2016 11:18:45 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resourceTypes/rt-123
@@ -190,7 +190,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:43 GMT
+      - Thu, 05 May 2016 11:18:45 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -206,7 +206,7 @@ http_interactions:
           "id" : "rt-123"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:43 GMT
+  recorded_at: Thu, 05 May 2016 11:18:45 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources
@@ -242,7 +242,7 @@ http_interactions:
       Location:
       - http://localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r123
       Date:
-      - Mon, 11 Apr 2016 16:51:43 GMT
+      - Thu, 05 May 2016 11:18:46 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -266,7 +266,7 @@ http_interactions:
           "id" : "r123"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:43 GMT
+  recorded_at: Thu, 05 May 2016 11:18:46 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r123
@@ -298,7 +298,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:43 GMT
+      - Thu, 05 May 2016 11:18:46 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -322,7 +322,7 @@ http_interactions:
           "id" : "r123"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:43 GMT
+  recorded_at: Thu, 05 May 2016 11:18:46 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r123
@@ -354,7 +354,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:43 GMT
+      - Thu, 05 May 2016 11:18:46 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -378,5 +378,5 @@ http_interactions:
           "id" : "r123"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:43 GMT
+  recorded_at: Thu, 05 May 2016 11:18:46 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_create_a_resourcetype.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_create_a_resourcetype.yml
@@ -35,7 +35,7 @@ http_interactions:
       Location:
       - http://localhost:8080/hawkular/inventory/feeds/feed_may_exist
       Date:
-      - Mon, 11 Apr 2016 16:51:42 GMT
+      - Thu, 05 May 2016 11:18:45 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -50,7 +50,7 @@ http_interactions:
           "id" : "feed_may_exist"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:42 GMT
+  recorded_at: Thu, 05 May 2016 11:18:45 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resourceTypes
@@ -86,7 +86,7 @@ http_interactions:
       Location:
       - http://localhost:8080/hawkular/inventory/feeds/feed_may_exist/resourceTypes/rt-123
       Date:
-      - Mon, 11 Apr 2016 16:51:43 GMT
+      - Thu, 05 May 2016 11:18:45 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -102,7 +102,7 @@ http_interactions:
           "id" : "rt-123"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:43 GMT
+  recorded_at: Thu, 05 May 2016 11:18:45 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resourceTypes/rt-123
@@ -134,7 +134,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:43 GMT
+      - Thu, 05 May 2016 11:18:45 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -150,5 +150,5 @@ http_interactions:
           "id" : "rt-123"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:43 GMT
+  recorded_at: Thu, 05 May 2016 11:18:45 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_create_and_delete_feed.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_create_and_delete_feed.yml
@@ -35,7 +35,7 @@ http_interactions:
       Location:
       - http://localhost:8080/hawkular/inventory/feeds/feed_1123sdn
       Date:
-      - Mon, 11 Apr 2016 16:51:42 GMT
+      - Thu, 05 May 2016 11:18:45 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -50,7 +50,7 @@ http_interactions:
           "id" : "feed_1123sdn"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:42 GMT
+  recorded_at: Thu, 05 May 2016 11:18:45 GMT
 - request:
     method: delete
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_1123sdn
@@ -82,12 +82,12 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:42 GMT
+      - Thu, 05 May 2016 11:18:45 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:42 GMT
+  recorded_at: Thu, 05 May 2016 11:18:45 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds
@@ -119,7 +119,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:42 GMT
+      - Thu, 05 May 2016 11:18:45 GMT
       X-Total-Count:
       - '2'
       Connection:
@@ -141,5 +141,5 @@ http_interactions:
           "id" : "feed_1123sdncisud6237ui23hjbdscuzsad"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:42 GMT
+  recorded_at: Thu, 05 May 2016 11:18:45 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_create_and_get_a_resource.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_create_and_get_a_resource.yml
@@ -33,7 +33,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:44 GMT
+      - Thu, 05 May 2016 11:18:48 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -62,7 +62,7 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:44 GMT
+  recorded_at: Thu, 05 May 2016 11:18:48 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist
@@ -94,7 +94,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:44 GMT
+      - Thu, 05 May 2016 11:18:48 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -109,7 +109,7 @@ http_interactions:
           "id" : "feed_may_exist"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:44 GMT
+  recorded_at: Thu, 05 May 2016 11:18:48 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resourceTypes
@@ -143,7 +143,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:44 GMT
+      - Thu, 05 May 2016 11:18:48 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -158,7 +158,7 @@ http_interactions:
           "details" : { }
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:44 GMT
+  recorded_at: Thu, 05 May 2016 11:18:48 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resourceTypes/rt-123
@@ -190,7 +190,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:44 GMT
+      - Thu, 05 May 2016 11:18:48 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -206,7 +206,7 @@ http_interactions:
           "id" : "rt-123"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:44 GMT
+  recorded_at: Thu, 05 May 2016 11:18:48 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources
@@ -242,7 +242,7 @@ http_interactions:
       Location:
       - http://localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r125
       Date:
-      - Mon, 11 Apr 2016 16:51:45 GMT
+      - Thu, 05 May 2016 11:18:48 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -266,7 +266,7 @@ http_interactions:
           "id" : "r125"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:45 GMT
+  recorded_at: Thu, 05 May 2016 11:18:48 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r125
@@ -298,7 +298,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:45 GMT
+      - Thu, 05 May 2016 11:18:48 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -322,7 +322,7 @@ http_interactions:
           "id" : "r125"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:45 GMT
+  recorded_at: Thu, 05 May 2016 11:18:48 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r125
@@ -354,7 +354,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:45 GMT
+      - Thu, 05 May 2016 11:18:48 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -378,7 +378,7 @@ http_interactions:
           "id" : "r125"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:45 GMT
+  recorded_at: Thu, 05 May 2016 11:18:48 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/feed_may_exist/resources/r125/data?dataType=configuration
@@ -410,7 +410,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:45 GMT
+      - Thu, 05 May 2016 11:18:48 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -430,5 +430,5 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:45 GMT
+  recorded_at: Thu, 05 May 2016 11:18:48 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_list_URLs.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_list_URLs.yml
@@ -31,7 +31,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:39 GMT
+      - Thu, 05 May 2016 11:18:41 GMT
       X-Total-Count:
       - '1'
       Connection:
@@ -39,7 +39,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '489'
+      - '465'
       Link:
       - <http://localhost:8080/hawkular/inventory/resourceTypes/URL/resources>; rel="current"
     body:
@@ -52,15 +52,14 @@ http_interactions:
             "id" : "URL"
           },
           "properties" : {
-            "trait-collected-on" : 1460393480039,
+            "hwk-gui-domainSort" : "http://bsd.de",
+            "trait-collected-on" : 1462447120360,
             "trait-powered-by" : "Apache",
-            "created" : 1460393407820,
-            "hwk-gui-domainSort" : "bsd.de",
             "trait-remote-address" : "212.86.200.189",
             "url" : "http://bsd.de"
           },
           "id" : "536cc3ede5769b60a49774425aedba24"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:39 GMT
+  recorded_at: Thu, 05 May 2016 11:18:41 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_list_WildFlys.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_list_WildFlys.yml
@@ -31,7 +31,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:39 GMT
+      - Thu, 05 May 2016 11:18:41 GMT
       X-Total-Count:
       - '1'
       Connection:
@@ -39,7 +39,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '357'
+      - '351'
       Link:
       - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resourceTypes/WildFly%20Server/resources>;
         rel="current"
@@ -53,9 +53,9 @@ http_interactions:
             "name" : "WildFly Server",
             "id" : "WildFly Server"
           },
-          "name" : "dhcp-10-40-1-43/Local",
+          "name" : "localhost/Local",
           "id" : "Local~~"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:39 GMT
+  recorded_at: Thu, 05 May 2016 11:18:41 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_list_WildFlys_with_props.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_list_WildFlys_with_props.yml
@@ -31,7 +31,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:39 GMT
+      - Thu, 05 May 2016 11:18:41 GMT
       X-Total-Count:
       - '1'
       Connection:
@@ -39,7 +39,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '357'
+      - '351'
       Link:
       - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resourceTypes/WildFly%20Server/resources>;
         rel="current"
@@ -53,11 +53,11 @@ http_interactions:
             "name" : "WildFly Server",
             "id" : "WildFly Server"
           },
-          "name" : "dhcp-10-40-1-43/Local",
+          "name" : "localhost/Local",
           "id" : "Local~~"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:39 GMT
+  recorded_at: Thu, 05 May 2016 11:18:41 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/data?dataType=configuration
@@ -89,13 +89,13 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:39 GMT
+      - Thu, 05 May 2016 11:18:41 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '360'
+      - '351'
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -111,5 +111,5 @@ http_interactions:
           "name" : "configuration"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:39 GMT
+  recorded_at: Thu, 05 May 2016 11:18:41 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_list_all_the_resource_types.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_list_all_the_resource_types.yml
@@ -31,7 +31,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:37 GMT
+      - Thu, 05 May 2016 11:18:39 GMT
       X-Total-Count:
       - '19'
       Connection:
@@ -122,5 +122,5 @@ http_interactions:
           "id" : "Hawkular WildFly Agent"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:37 GMT
+  recorded_at: Thu, 05 May 2016 11:18:39 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_list_children_of_WildFly.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_list_children_of_WildFly.yml
@@ -31,7 +31,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:39 GMT
+      - Thu, 05 May 2016 11:18:42 GMT
       X-Total-Count:
       - '1'
       Connection:
@@ -39,7 +39,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '357'
+      - '351'
       Link:
       - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resourceTypes/WildFly%20Server/resources>;
         rel="current"
@@ -53,11 +53,11 @@ http_interactions:
             "name" : "WildFly Server",
             "id" : "WildFly Server"
           },
-          "name" : "dhcp-10-40-1-43/Local",
+          "name" : "localhost/Local",
           "id" : "Local~~"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:39 GMT
+  recorded_at: Thu, 05 May 2016 11:18:42 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/children
@@ -89,7 +89,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:39 GMT
+      - Thu, 05 May 2016 11:18:42 GMT
       X-Total-Count:
       - '22'
       Connection:
@@ -304,5 +304,5 @@ http_interactions:
           "id" : "Local~/subsystem=hawkular-wildfly-agent"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:39 GMT
+  recorded_at: Thu, 05 May 2016 11:18:42 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_list_children_of_nested_resource.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_list_children_of_nested_resource.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/tenant
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/Local~%2Fsubsystem=datasources%2Fdata-source=ExampleDS
     body:
       encoding: US-ASCII
       string: ''
@@ -31,25 +31,31 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 05 May 2016 11:18:48 GMT
+      - Thu, 05 May 2016 11:18:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '105'
+      - '431'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf",
-          "id" : "28026b36-8fe4-4332-84c8-524e173a68bf"
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/rt;Datasource",
+            "name" : "Datasource",
+            "id" : "Datasource"
+          },
+          "name" : "ExampleDS",
+          "id" : "Local~/subsystem=datasources/data-source=ExampleDS"
         }
     http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:48 GMT
+  recorded_at: Thu, 05 May 2016 11:18:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/tenant
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/Local~%2Fsubsystem=datasources%2Fdata-source=ExampleDS/data?dataType=configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -78,25 +84,33 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 05 May 2016 11:18:48 GMT
+      - Thu, 05 May 2016 11:18:42 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '105'
+      - '462'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf",
-          "id" : "28026b36-8fe4-4332-84c8-524e173a68bf"
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/d;configuration",
+          "value" : {
+            "Username" : "sa",
+            "Driver Name" : "h2",
+            "JNDI Name" : "java:jboss/datasources/ExampleDS",
+            "Connection URL" : "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+            "Enabled" : "true",
+            "Password" : "sa"
+          },
+          "name" : "configuration"
         }
     http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:48 GMT
+  recorded_at: Thu, 05 May 2016 11:18:42 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/tenant
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/Local~%2Fsubsystem=datasources%2Fdata-source=ExampleDS/children
     body:
       encoding: US-ASCII
       string: ''
@@ -125,67 +139,21 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 05 May 2016 11:18:48 GMT
+      - Thu, 05 May 2016 11:18:42 GMT
+      X-Total-Count:
+      - "-1"
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '105'
+      - '3'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/children>;
+        rel="current"
     body:
       encoding: ASCII-8BIT
-      string: |-
-        {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf",
-          "id" : "28026b36-8fe4-4332-84c8-524e173a68bf"
-        }
+      string: "[ ]"
     http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:48 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/tenant
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Thu, 05 May 2016 11:18:48 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '105'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf",
-          "id" : "28026b36-8fe4-4332-84c8-524e173a68bf"
-        }
-    http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:48 GMT
+  recorded_at: Thu, 05 May 2016 11:18:42 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_list_feeds.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_list_feeds.yml
@@ -31,7 +31,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:37 GMT
+      - Thu, 05 May 2016 11:18:38 GMT
       X-Total-Count:
       - '1'
       Connection:
@@ -50,5 +50,5 @@ http_interactions:
           "id" : "<%= feed_uuid %>"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:37 GMT
+  recorded_at: Thu, 05 May 2016 11:18:38 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_list_heap_metrics_for_WildFlys.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_list_heap_metrics_for_WildFlys.yml
@@ -31,7 +31,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:41 GMT
+      - Thu, 05 May 2016 11:18:43 GMT
       X-Total-Count:
       - '1'
       Connection:
@@ -39,7 +39,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '357'
+      - '351'
       Link:
       - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resourceTypes/WildFly%20Server/resources>;
         rel="current"
@@ -53,14 +53,14 @@ http_interactions:
             "name" : "WildFly Server",
             "id" : "WildFly Server"
           },
-          "name" : "dhcp-10-40-1-43/Local",
+          "name" : "localhost/Local",
           "id" : "Local~~"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:41 GMT
+  recorded_at: Thu, 05 May 2016 11:18:43 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics?sort=id
     body:
       encoding: US-ASCII
       string: ''
@@ -89,7 +89,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:41 GMT
+      - Thu, 05 May 2016 11:18:43 GMT
       X-Total-Count:
       - '14'
       Connection:
@@ -99,35 +99,23 @@ http_interactions:
       Content-Length:
       - '10779'
       Link:
-      - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics>;
+      - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics?sort=id>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;AI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~AT~Server%20Availability~App%20Server",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Committed",
-            "name" : "WildFly Memory Metrics~NonHeap Committed",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Server%20Availability~App%20Server",
+            "name" : "Server Availability~App Server",
             "unit" : "NONE",
-            "type" : "GAUGE",
-            "collectionInterval" : 60,
-            "id" : "WildFly Memory Metrics~NonHeap Committed"
+            "type" : "AVAILABILITY",
+            "collectionInterval" : 30,
+            "id" : "Server Availability~App Server"
           },
-          "name" : "WildFly Memory Metrics~NonHeap Committed",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Committed"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
+          "name" : "Server Availability~App Server",
+          "id" : "AI~R~[<%= feed_uuid %>/Local~~]~AT~Server Availability~App Server"
         }, {
           "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions",
           "type" : {
@@ -141,17 +129,77 @@ http_interactions:
           "name" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions",
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Used",
-            "name" : "WildFly Memory Metrics~NonHeap Used",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
             "unit" : "NONE",
             "type" : "GAUGE",
-            "collectionInterval" : 30,
-            "id" : "WildFly Memory Metrics~NonHeap Used"
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
-          "name" : "WildFly Memory Metrics~NonHeap Used",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Used"
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
+            "name" : "WildFly Memory Metrics~Accumulated GC Duration",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Memory Metrics~Accumulated GC Duration"
+          },
+          "name" : "WildFly Memory Metrics~Accumulated GC Duration",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Accumulated GC Duration"
         }, {
           "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed",
           "type" : {
@@ -177,42 +225,6 @@ http_interactions:
           "name" : "WildFly Memory Metrics~Heap Max",
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Heap Max"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Threading%20Metrics~Thread%20Count",
-            "name" : "WildFly Threading Metrics~Thread Count",
-            "unit" : "NONE",
-            "type" : "GAUGE",
-            "collectionInterval" : 120,
-            "id" : "WildFly Threading Metrics~Thread Count"
-          },
-          "name" : "WildFly Threading Metrics~Thread Count",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
-            "name" : "WildFly Memory Metrics~Accumulated GC Duration",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Memory Metrics~Accumulated GC Duration"
-          },
-          "name" : "WildFly Memory Metrics~Accumulated GC Duration",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Accumulated GC Duration"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
-        }, {
           "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used",
           "type" : {
             "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~Heap%20Used",
@@ -225,59 +237,47 @@ http_interactions:
           "name" : "WildFly Memory Metrics~Heap Used",
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Heap Used"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Committed",
+            "name" : "WildFly Memory Metrics~NonHeap Committed",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
+            "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
+          "name" : "WildFly Memory Metrics~NonHeap Committed",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Committed"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;AI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~AT~Server%20Availability~App%20Server",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Server%20Availability~App%20Server",
-            "name" : "Server Availability~App Server",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Used",
+            "name" : "WildFly Memory Metrics~NonHeap Used",
             "unit" : "NONE",
-            "type" : "AVAILABILITY",
+            "type" : "GAUGE",
             "collectionInterval" : 30,
-            "id" : "Server Availability~App Server"
+            "id" : "WildFly Memory Metrics~NonHeap Used"
           },
-          "name" : "Server Availability~App Server",
-          "id" : "AI~R~[<%= feed_uuid %>/Local~~]~AT~Server Availability~App Server"
+          "name" : "WildFly Memory Metrics~NonHeap Used",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Used"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Threading%20Metrics~Thread%20Count",
+            "name" : "WildFly Threading Metrics~Thread Count",
+            "unit" : "NONE",
+            "type" : "GAUGE",
+            "collectionInterval" : 120,
+            "id" : "WildFly Threading Metrics~Thread Count"
+          },
+          "name" : "WildFly Threading Metrics~Thread Count",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:41 GMT
+  recorded_at: Thu, 05 May 2016 11:18:43 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics?sort=id
     body:
       encoding: US-ASCII
       string: ''
@@ -306,7 +306,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:41 GMT
+      - Thu, 05 May 2016 11:18:43 GMT
       X-Total-Count:
       - '14'
       Connection:
@@ -316,35 +316,23 @@ http_interactions:
       Content-Length:
       - '10779'
       Link:
-      - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics>;
+      - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics?sort=id>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;AI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~AT~Server%20Availability~App%20Server",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Committed",
-            "name" : "WildFly Memory Metrics~NonHeap Committed",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Server%20Availability~App%20Server",
+            "name" : "Server Availability~App Server",
             "unit" : "NONE",
-            "type" : "GAUGE",
-            "collectionInterval" : 60,
-            "id" : "WildFly Memory Metrics~NonHeap Committed"
+            "type" : "AVAILABILITY",
+            "collectionInterval" : 30,
+            "id" : "Server Availability~App Server"
           },
-          "name" : "WildFly Memory Metrics~NonHeap Committed",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Committed"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
+          "name" : "Server Availability~App Server",
+          "id" : "AI~R~[<%= feed_uuid %>/Local~~]~AT~Server Availability~App Server"
         }, {
           "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions",
           "type" : {
@@ -358,17 +346,77 @@ http_interactions:
           "name" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions",
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Used",
-            "name" : "WildFly Memory Metrics~NonHeap Used",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
             "unit" : "NONE",
             "type" : "GAUGE",
-            "collectionInterval" : 30,
-            "id" : "WildFly Memory Metrics~NonHeap Used"
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
-          "name" : "WildFly Memory Metrics~NonHeap Used",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Used"
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
+            "name" : "WildFly Memory Metrics~Accumulated GC Duration",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Memory Metrics~Accumulated GC Duration"
+          },
+          "name" : "WildFly Memory Metrics~Accumulated GC Duration",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Accumulated GC Duration"
         }, {
           "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed",
           "type" : {
@@ -394,42 +442,6 @@ http_interactions:
           "name" : "WildFly Memory Metrics~Heap Max",
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Heap Max"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Threading%20Metrics~Thread%20Count",
-            "name" : "WildFly Threading Metrics~Thread Count",
-            "unit" : "NONE",
-            "type" : "GAUGE",
-            "collectionInterval" : 120,
-            "id" : "WildFly Threading Metrics~Thread Count"
-          },
-          "name" : "WildFly Threading Metrics~Thread Count",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
-            "name" : "WildFly Memory Metrics~Accumulated GC Duration",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Memory Metrics~Accumulated GC Duration"
-          },
-          "name" : "WildFly Memory Metrics~Accumulated GC Duration",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Accumulated GC Duration"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
-        }, {
           "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used",
           "type" : {
             "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~Heap%20Used",
@@ -442,59 +454,47 @@ http_interactions:
           "name" : "WildFly Memory Metrics~Heap Used",
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Heap Used"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Committed",
+            "name" : "WildFly Memory Metrics~NonHeap Committed",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
+            "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
+          "name" : "WildFly Memory Metrics~NonHeap Committed",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Committed"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;AI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~AT~Server%20Availability~App%20Server",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Server%20Availability~App%20Server",
-            "name" : "Server Availability~App Server",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Used",
+            "name" : "WildFly Memory Metrics~NonHeap Used",
             "unit" : "NONE",
-            "type" : "AVAILABILITY",
+            "type" : "GAUGE",
             "collectionInterval" : 30,
-            "id" : "Server Availability~App Server"
+            "id" : "WildFly Memory Metrics~NonHeap Used"
           },
-          "name" : "Server Availability~App Server",
-          "id" : "AI~R~[<%= feed_uuid %>/Local~~]~AT~Server Availability~App Server"
+          "name" : "WildFly Memory Metrics~NonHeap Used",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Used"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Threading%20Metrics~Thread%20Count",
+            "name" : "WildFly Threading Metrics~Thread Count",
+            "unit" : "NONE",
+            "type" : "GAUGE",
+            "collectionInterval" : 120,
+            "id" : "WildFly Threading Metrics~Thread Count"
+          },
+          "name" : "WildFly Threading Metrics~Thread Count",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:41 GMT
+  recorded_at: Thu, 05 May 2016 11:18:43 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics?sort=id
     body:
       encoding: US-ASCII
       string: ''
@@ -523,7 +523,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:41 GMT
+      - Thu, 05 May 2016 11:18:44 GMT
       X-Total-Count:
       - '14'
       Connection:
@@ -533,35 +533,23 @@ http_interactions:
       Content-Length:
       - '10779'
       Link:
-      - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics>;
+      - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics?sort=id>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;AI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~AT~Server%20Availability~App%20Server",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Committed",
-            "name" : "WildFly Memory Metrics~NonHeap Committed",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Server%20Availability~App%20Server",
+            "name" : "Server Availability~App Server",
             "unit" : "NONE",
-            "type" : "GAUGE",
-            "collectionInterval" : 60,
-            "id" : "WildFly Memory Metrics~NonHeap Committed"
+            "type" : "AVAILABILITY",
+            "collectionInterval" : 30,
+            "id" : "Server Availability~App Server"
           },
-          "name" : "WildFly Memory Metrics~NonHeap Committed",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Committed"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
+          "name" : "Server Availability~App Server",
+          "id" : "AI~R~[<%= feed_uuid %>/Local~~]~AT~Server Availability~App Server"
         }, {
           "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions",
           "type" : {
@@ -575,17 +563,77 @@ http_interactions:
           "name" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions",
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Used",
-            "name" : "WildFly Memory Metrics~NonHeap Used",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
             "unit" : "NONE",
             "type" : "GAUGE",
-            "collectionInterval" : 30,
-            "id" : "WildFly Memory Metrics~NonHeap Used"
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
-          "name" : "WildFly Memory Metrics~NonHeap Used",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Used"
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
+            "name" : "WildFly Memory Metrics~Accumulated GC Duration",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Memory Metrics~Accumulated GC Duration"
+          },
+          "name" : "WildFly Memory Metrics~Accumulated GC Duration",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Accumulated GC Duration"
         }, {
           "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed",
           "type" : {
@@ -611,42 +659,6 @@ http_interactions:
           "name" : "WildFly Memory Metrics~Heap Max",
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Heap Max"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Threading%20Metrics~Thread%20Count",
-            "name" : "WildFly Threading Metrics~Thread Count",
-            "unit" : "NONE",
-            "type" : "GAUGE",
-            "collectionInterval" : 120,
-            "id" : "WildFly Threading Metrics~Thread Count"
-          },
-          "name" : "WildFly Threading Metrics~Thread Count",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
-            "name" : "WildFly Memory Metrics~Accumulated GC Duration",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Memory Metrics~Accumulated GC Duration"
-          },
-          "name" : "WildFly Memory Metrics~Accumulated GC Duration",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Accumulated GC Duration"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
-        }, {
           "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used",
           "type" : {
             "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~Heap%20Used",
@@ -659,54 +671,42 @@ http_interactions:
           "name" : "WildFly Memory Metrics~Heap Used",
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Heap Used"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Committed",
+            "name" : "WildFly Memory Metrics~NonHeap Committed",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
+            "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
+          "name" : "WildFly Memory Metrics~NonHeap Committed",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Committed"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;AI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~AT~Server%20Availability~App%20Server",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Server%20Availability~App%20Server",
-            "name" : "Server Availability~App Server",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Used",
+            "name" : "WildFly Memory Metrics~NonHeap Used",
             "unit" : "NONE",
-            "type" : "AVAILABILITY",
+            "type" : "GAUGE",
             "collectionInterval" : 30,
-            "id" : "Server Availability~App Server"
+            "id" : "WildFly Memory Metrics~NonHeap Used"
           },
-          "name" : "Server Availability~App Server",
-          "id" : "AI~R~[<%= feed_uuid %>/Local~~]~AT~Server Availability~App Server"
+          "name" : "WildFly Memory Metrics~NonHeap Used",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Used"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Threading%20Metrics~Thread%20Count",
+            "name" : "WildFly Threading Metrics~Thread Count",
+            "unit" : "NONE",
+            "type" : "GAUGE",
+            "collectionInterval" : 120,
+            "id" : "WildFly Threading Metrics~Thread Count"
+          },
+          "name" : "WildFly Threading Metrics~Thread Count",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:41 GMT
+  recorded_at: Thu, 05 May 2016 11:18:44 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_list_metrics_for_WildFlys.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_list_metrics_for_WildFlys.yml
@@ -31,7 +31,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:39 GMT
+      - Thu, 05 May 2016 11:18:41 GMT
       X-Total-Count:
       - '1'
       Connection:
@@ -39,7 +39,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '357'
+      - '351'
       Link:
       - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resourceTypes/WildFly%20Server/resources>;
         rel="current"
@@ -53,14 +53,14 @@ http_interactions:
             "name" : "WildFly Server",
             "id" : "WildFly Server"
           },
-          "name" : "dhcp-10-40-1-43/Local",
+          "name" : "localhost/Local",
           "id" : "Local~~"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:39 GMT
+  recorded_at: Thu, 05 May 2016 11:18:41 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics?sort=id
     body:
       encoding: US-ASCII
       string: ''
@@ -89,7 +89,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:39 GMT
+      - Thu, 05 May 2016 11:18:42 GMT
       X-Total-Count:
       - '14'
       Connection:
@@ -99,35 +99,23 @@ http_interactions:
       Content-Length:
       - '10779'
       Link:
-      - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics>;
+      - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics?sort=id>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;AI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~AT~Server%20Availability~App%20Server",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Committed",
-            "name" : "WildFly Memory Metrics~NonHeap Committed",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Server%20Availability~App%20Server",
+            "name" : "Server Availability~App Server",
             "unit" : "NONE",
-            "type" : "GAUGE",
-            "collectionInterval" : 60,
-            "id" : "WildFly Memory Metrics~NonHeap Committed"
+            "type" : "AVAILABILITY",
+            "collectionInterval" : 30,
+            "id" : "Server Availability~App Server"
           },
-          "name" : "WildFly Memory Metrics~NonHeap Committed",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Committed"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
+          "name" : "Server Availability~App Server",
+          "id" : "AI~R~[<%= feed_uuid %>/Local~~]~AT~Server Availability~App Server"
         }, {
           "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions",
           "type" : {
@@ -141,17 +129,77 @@ http_interactions:
           "name" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions",
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Used",
-            "name" : "WildFly Memory Metrics~NonHeap Used",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
             "unit" : "NONE",
             "type" : "GAUGE",
-            "collectionInterval" : 30,
-            "id" : "WildFly Memory Metrics~NonHeap Used"
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
-          "name" : "WildFly Memory Metrics~NonHeap Used",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Used"
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
+            "name" : "WildFly Memory Metrics~Accumulated GC Duration",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Memory Metrics~Accumulated GC Duration"
+          },
+          "name" : "WildFly Memory Metrics~Accumulated GC Duration",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Accumulated GC Duration"
         }, {
           "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed",
           "type" : {
@@ -177,42 +225,6 @@ http_interactions:
           "name" : "WildFly Memory Metrics~Heap Max",
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Heap Max"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Threading%20Metrics~Thread%20Count",
-            "name" : "WildFly Threading Metrics~Thread Count",
-            "unit" : "NONE",
-            "type" : "GAUGE",
-            "collectionInterval" : 120,
-            "id" : "WildFly Threading Metrics~Thread Count"
-          },
-          "name" : "WildFly Threading Metrics~Thread Count",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
-            "name" : "WildFly Memory Metrics~Accumulated GC Duration",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Memory Metrics~Accumulated GC Duration"
-          },
-          "name" : "WildFly Memory Metrics~Accumulated GC Duration",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Accumulated GC Duration"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
-        }, {
           "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used",
           "type" : {
             "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~Heap%20Used",
@@ -225,54 +237,42 @@ http_interactions:
           "name" : "WildFly Memory Metrics~Heap Used",
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Heap Used"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Committed",
+            "name" : "WildFly Memory Metrics~NonHeap Committed",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
+            "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
+          "name" : "WildFly Memory Metrics~NonHeap Committed",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Committed"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;AI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~AT~Server%20Availability~App%20Server",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Server%20Availability~App%20Server",
-            "name" : "Server Availability~App Server",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Used",
+            "name" : "WildFly Memory Metrics~NonHeap Used",
             "unit" : "NONE",
-            "type" : "AVAILABILITY",
+            "type" : "GAUGE",
             "collectionInterval" : 30,
-            "id" : "Server Availability~App Server"
+            "id" : "WildFly Memory Metrics~NonHeap Used"
           },
-          "name" : "Server Availability~App Server",
-          "id" : "AI~R~[<%= feed_uuid %>/Local~~]~AT~Server Availability~App Server"
+          "name" : "WildFly Memory Metrics~NonHeap Used",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Used"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Threading%20Metrics~Thread%20Count",
+            "name" : "WildFly Threading Metrics~Thread Count",
+            "unit" : "NONE",
+            "type" : "GAUGE",
+            "collectionInterval" : 120,
+            "id" : "WildFly Threading Metrics~Thread Count"
+          },
+          "name" : "WildFly Threading Metrics~Thread Count",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:39 GMT
+  recorded_at: Thu, 05 May 2016 11:18:42 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_list_metrics_of_given_metric_type.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_list_metrics_of_given_metric_type.yml
@@ -31,7 +31,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:41 GMT
+      - Thu, 05 May 2016 11:18:44 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -50,10 +50,10 @@ http_interactions:
           "id" : "Total Space"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:41 GMT
+  recorded_at: Thu, 05 May 2016 11:18:44 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space/relationships?named=defines
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space/relationships?named=defines&sort=__targetCp
     body:
       encoding: US-ASCII
       string: ''
@@ -82,7 +82,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:41 GMT
+      - Thu, 05 May 2016 11:18:44 GMT
       X-Total-Count:
       - '7'
       Connection:
@@ -92,13 +92,18 @@ http_interactions:
       Content-Length:
       - '3102'
       Link:
-      - <http://localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space/relationships?named=defines>;
+      - <http://localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space/relationships?sort=__targetCp&named=defines>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "id" : "1i00-9hc-1g5x-1clc",
+          "id" : "1jwg-9hc-1g5x-1erk",
+          "name" : "defines",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3D%2Fdev%2Fmapper%2Ffedora-home%5D~MT~Total%20Space"
+        }, {
+          "id" : "1iow-9hc-1g5x-1dds",
           "name" : "defines",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
           "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3D%2Fdev%2Fsda3%5D~MT~Total%20Space"
@@ -106,147 +111,30 @@ http_interactions:
           "id" : "1iio-9hc-1g5x-1d6o",
           "name" : "defines",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3Dtmpfs%5D~MT~Total%20Space"
-        }, {
-          "id" : "1iow-9hc-1g5x-1dds",
-          "name" : "defines",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3D%2Fdev%2Fmapper%2Ffedora-home%5D~MT~Total%20Space"
-        }, {
-          "id" : "1j1c-9hc-1g5x-1ds0",
-          "name" : "defines",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3Dsunrpc%5D~MT~Total%20Space"
-        }, {
-          "id" : "1jds-9hc-1g5x-1e68",
-          "name" : "defines",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3D~%5D~MT~Total%20Space"
-        }, {
-          "id" : "1jq8-9hc-1g5x-1ekg",
-          "name" : "defines",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3Dmqueue%5D~MT~Total%20Space"
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3Dhugetlbfs%5D~MT~Total%20Space"
         }, {
           "id" : "1k8w-9hc-1g5x-1f5s",
           "name" : "defines",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3Dhugetlbfs%5D~MT~Total%20Space"
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3Dmqueue%5D~MT~Total%20Space"
+        }, {
+          "id" : "1jk0-9hc-1g5x-1edc",
+          "name" : "defines",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3Dsunrpc%5D~MT~Total%20Space"
+        }, {
+          "id" : "1i68-9hc-1g5x-1csg",
+          "name" : "defines",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3Dtmpfs%5D~MT~Total%20Space"
+        }, {
+          "id" : "1j1c-9hc-1g5x-1ds0",
+          "name" : "defines",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3D~%5D~MT~Total%20Space"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:41 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem%2FFILE_STORE=%2Fdev%2Fsda3%5D~MT~Total%20Space
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 11 Apr 2016 16:51:41 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '734'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3D%2Fdev%2Fsda3%5D~MT~Total%20Space",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
-            "name" : "Total Space",
-            "unit" : "BYTES",
-            "type" : "GAUGE",
-            "collectionInterval" : 300,
-            "id" : "Total Space"
-          },
-          "name" : "Total Space",
-          "id" : "MI~R~[<%= feed_uuid %>/platform~/OPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem/FILE_STORE=/dev/sda3]~MT~Total Space"
-        }
-    http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:41 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem%2FFILE_STORE=tmpfs%5D~MT~Total%20Space
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 11 Apr 2016 16:51:41 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '722'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3Dtmpfs%5D~MT~Total%20Space",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
-            "name" : "Total Space",
-            "unit" : "BYTES",
-            "type" : "GAUGE",
-            "collectionInterval" : 300,
-            "id" : "Total Space"
-          },
-          "name" : "Total Space",
-          "id" : "MI~R~[<%= feed_uuid %>/platform~/OPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem/FILE_STORE=tmpfs]~MT~Total Space"
-        }
-    http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:41 GMT
+  recorded_at: Thu, 05 May 2016 11:18:44 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem%2FFILE_STORE=%2Fdev%2Fmapper%2Ffedora-home%5D~MT~Total%20Space
@@ -278,7 +166,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:41 GMT
+      - Thu, 05 May 2016 11:18:44 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -302,10 +190,10 @@ http_interactions:
           "id" : "MI~R~[<%= feed_uuid %>/platform~/OPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem/FILE_STORE=/dev/mapper/fedora-home]~MT~Total Space"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:41 GMT
+  recorded_at: Thu, 05 May 2016 11:18:44 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem%2FFILE_STORE=sunrpc%5D~MT~Total%20Space
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem%2FFILE_STORE=%2Fdev%2Fsda3%5D~MT~Total%20Space
     body:
       encoding: US-ASCII
       string: ''
@@ -334,18 +222,18 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:41 GMT
+      - Thu, 05 May 2016 11:18:44 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '724'
+      - '734'
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3Dsunrpc%5D~MT~Total%20Space",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3D%2Fdev%2Fsda3%5D~MT~Total%20Space",
           "type" : {
             "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
             "name" : "Total Space",
@@ -355,122 +243,10 @@ http_interactions:
             "id" : "Total Space"
           },
           "name" : "Total Space",
-          "id" : "MI~R~[<%= feed_uuid %>/platform~/OPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem/FILE_STORE=sunrpc]~MT~Total Space"
+          "id" : "MI~R~[<%= feed_uuid %>/platform~/OPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem/FILE_STORE=/dev/sda3]~MT~Total Space"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:41 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem%2FFILE_STORE=~%5D~MT~Total%20Space
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 11 Apr 2016 16:51:41 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '714'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3D~%5D~MT~Total%20Space",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
-            "name" : "Total Space",
-            "unit" : "BYTES",
-            "type" : "GAUGE",
-            "collectionInterval" : 300,
-            "id" : "Total Space"
-          },
-          "name" : "Total Space",
-          "id" : "MI~R~[<%= feed_uuid %>/platform~/OPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem/FILE_STORE=~]~MT~Total Space"
-        }
-    http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:41 GMT
-- request:
-    method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem%2FFILE_STORE=mqueue%5D~MT~Total%20Space
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Expires:
-      - '0'
-      Cache-Control:
-      - no-cache, no-store, must-revalidate
-      X-Powered-By:
-      - Undertow/1
-      Server:
-      - WildFly/10
-      Pragma:
-      - no-cache
-      Date:
-      - Mon, 11 Apr 2016 16:51:41 GMT
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '724'
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3Dmqueue%5D~MT~Total%20Space",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
-            "name" : "Total Space",
-            "unit" : "BYTES",
-            "type" : "GAUGE",
-            "collectionInterval" : 300,
-            "id" : "Total Space"
-          },
-          "name" : "Total Space",
-          "id" : "MI~R~[<%= feed_uuid %>/platform~/OPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem/FILE_STORE=mqueue]~MT~Total Space"
-        }
-    http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:41 GMT
+  recorded_at: Thu, 05 May 2016 11:18:44 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem%2FFILE_STORE=hugetlbfs%5D~MT~Total%20Space
@@ -502,7 +278,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:41 GMT
+      - Thu, 05 May 2016 11:18:44 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -526,5 +302,229 @@ http_interactions:
           "id" : "MI~R~[<%= feed_uuid %>/platform~/OPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem/FILE_STORE=hugetlbfs]~MT~Total Space"
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:41 GMT
+  recorded_at: Thu, 05 May 2016 11:18:44 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem%2FFILE_STORE=mqueue%5D~MT~Total%20Space
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 05 May 2016 11:18:44 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '724'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3Dmqueue%5D~MT~Total%20Space",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
+            "name" : "Total Space",
+            "unit" : "BYTES",
+            "type" : "GAUGE",
+            "collectionInterval" : 300,
+            "id" : "Total Space"
+          },
+          "name" : "Total Space",
+          "id" : "MI~R~[<%= feed_uuid %>/platform~/OPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem/FILE_STORE=mqueue]~MT~Total Space"
+        }
+    http_version: 
+  recorded_at: Thu, 05 May 2016 11:18:44 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem%2FFILE_STORE=sunrpc%5D~MT~Total%20Space
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 05 May 2016 11:18:44 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '724'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3Dsunrpc%5D~MT~Total%20Space",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
+            "name" : "Total Space",
+            "unit" : "BYTES",
+            "type" : "GAUGE",
+            "collectionInterval" : 300,
+            "id" : "Total Space"
+          },
+          "name" : "Total Space",
+          "id" : "MI~R~[<%= feed_uuid %>/platform~/OPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem/FILE_STORE=sunrpc]~MT~Total Space"
+        }
+    http_version: 
+  recorded_at: Thu, 05 May 2016 11:18:44 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem%2FFILE_STORE=tmpfs%5D~MT~Total%20Space
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 05 May 2016 11:18:44 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '722'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3Dtmpfs%5D~MT~Total%20Space",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
+            "name" : "Total Space",
+            "unit" : "BYTES",
+            "type" : "GAUGE",
+            "collectionInterval" : 300,
+            "id" : "Total Space"
+          },
+          "name" : "Total Space",
+          "id" : "MI~R~[<%= feed_uuid %>/platform~/OPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem/FILE_STORE=tmpfs]~MT~Total Space"
+        }
+    http_version: 
+  recorded_at: Thu, 05 May 2016 11:18:44 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem%2FFILE_STORE=~%5D~MT~Total%20Space
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 05 May 2016 11:18:44 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '714'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2Fplatform~%2FOPERATING_SYSTEM%3D<%= feed_uuid %>_OperatingSystem%2FFILE_STORE%3D~%5D~MT~Total%20Space",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Total%20Space",
+            "name" : "Total Space",
+            "unit" : "BYTES",
+            "type" : "GAUGE",
+            "collectionInterval" : 300,
+            "id" : "Total Space"
+          },
+          "name" : "Total Space",
+          "id" : "MI~R~[<%= feed_uuid %>/platform~/OPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem/FILE_STORE=~]~MT~Total Space"
+        }
+    http_version: 
+  recorded_at: Thu, 05 May 2016 11:18:44 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_list_metrics_of_given_resource_type.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_list_metrics_of_given_resource_type.yml
@@ -31,7 +31,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:41 GMT
+      - Thu, 05 May 2016 11:18:44 GMT
       X-Total-Count:
       - '1'
       Connection:
@@ -39,7 +39,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '357'
+      - '351'
       Link:
       - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resourceTypes/WildFly%20Server/resources>;
         rel="current"
@@ -53,14 +53,14 @@ http_interactions:
             "name" : "WildFly Server",
             "id" : "WildFly Server"
           },
-          "name" : "dhcp-10-40-1-43/Local",
+          "name" : "localhost/Local",
           "id" : "Local~~"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:41 GMT
+  recorded_at: Thu, 05 May 2016 11:18:44 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics?sort=id
     body:
       encoding: US-ASCII
       string: ''
@@ -89,7 +89,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:41 GMT
+      - Thu, 05 May 2016 11:18:44 GMT
       X-Total-Count:
       - '14'
       Connection:
@@ -99,35 +99,23 @@ http_interactions:
       Content-Length:
       - '10779'
       Link:
-      - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics>;
+      - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/metrics?sort=id>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;AI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~AT~Server%20Availability~App%20Server",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Committed",
-            "name" : "WildFly Memory Metrics~NonHeap Committed",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Server%20Availability~App%20Server",
+            "name" : "Server Availability~App Server",
             "unit" : "NONE",
-            "type" : "GAUGE",
-            "collectionInterval" : 60,
-            "id" : "WildFly Memory Metrics~NonHeap Committed"
+            "type" : "AVAILABILITY",
+            "collectionInterval" : 30,
+            "id" : "Server Availability~App Server"
           },
-          "name" : "WildFly Memory Metrics~NonHeap Committed",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Committed"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
+          "name" : "Server Availability~App Server",
+          "id" : "AI~R~[<%= feed_uuid %>/Local~~]~AT~Server Availability~App Server"
         }, {
           "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions",
           "type" : {
@@ -141,17 +129,77 @@ http_interactions:
           "name" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions",
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Used",
-            "name" : "WildFly Memory Metrics~NonHeap Used",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
             "unit" : "NONE",
             "type" : "GAUGE",
-            "collectionInterval" : 30,
-            "id" : "WildFly Memory Metrics~NonHeap Used"
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
-          "name" : "WildFly Memory Metrics~NonHeap Used",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Used"
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
+          },
+          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
+            "name" : "WildFly Memory Metrics~Accumulated GC Duration",
+            "unit" : "NONE",
+            "type" : "COUNTER",
+            "collectionInterval" : 60,
+            "id" : "WildFly Memory Metrics~Accumulated GC Duration"
+          },
+          "name" : "WildFly Memory Metrics~Accumulated GC Duration",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Accumulated GC Duration"
         }, {
           "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed",
           "type" : {
@@ -177,42 +225,6 @@ http_interactions:
           "name" : "WildFly Memory Metrics~Heap Max",
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Heap Max"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Threading%20Metrics~Thread%20Count",
-            "name" : "WildFly Threading Metrics~Thread Count",
-            "unit" : "NONE",
-            "type" : "GAUGE",
-            "collectionInterval" : 120,
-            "id" : "WildFly Threading Metrics~Thread Count"
-          },
-          "name" : "WildFly Threading Metrics~Thread Count",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration",
-            "name" : "WildFly Memory Metrics~Accumulated GC Duration",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Memory Metrics~Accumulated GC Duration"
-          },
-          "name" : "WildFly Memory Metrics~Accumulated GC Duration",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Accumulated GC Duration"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
-        }, {
           "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used",
           "type" : {
             "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~Heap%20Used",
@@ -225,54 +237,42 @@ http_interactions:
           "name" : "WildFly Memory Metrics~Heap Used",
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~Heap Used"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
-            "unit" : "NONE",
-            "type" : "COUNTER",
-            "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
-          },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
-        }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
-          "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions",
-            "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Committed",
+            "name" : "WildFly Memory Metrics~NonHeap Committed",
             "unit" : "NONE",
             "type" : "GAUGE",
             "collectionInterval" : 60,
-            "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
+            "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
-          "name" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions",
-          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
+          "name" : "WildFly Memory Metrics~NonHeap Committed",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Committed"
         }, {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;AI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~AT~Server%20Availability~App%20Server",
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used",
           "type" : {
-            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;Server%20Availability~App%20Server",
-            "name" : "Server Availability~App Server",
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Memory%20Metrics~NonHeap%20Used",
+            "name" : "WildFly Memory Metrics~NonHeap Used",
             "unit" : "NONE",
-            "type" : "AVAILABILITY",
+            "type" : "GAUGE",
             "collectionInterval" : 30,
-            "id" : "Server Availability~App Server"
+            "id" : "WildFly Memory Metrics~NonHeap Used"
           },
-          "name" : "Server Availability~App Server",
-          "id" : "AI~R~[<%= feed_uuid %>/Local~~]~AT~Server Availability~App Server"
+          "name" : "WildFly Memory Metrics~NonHeap Used",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Memory Metrics~NonHeap Used"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/mt;WildFly%20Threading%20Metrics~Thread%20Count",
+            "name" : "WildFly Threading Metrics~Thread Count",
+            "unit" : "NONE",
+            "type" : "GAUGE",
+            "collectionInterval" : 120,
+            "id" : "WildFly Threading Metrics~Thread Count"
+          },
+          "name" : "WildFly Threading Metrics~Thread Count",
+          "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:41 GMT
+  recorded_at: Thu, 05 May 2016 11:18:44 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_list_recursive_children_of_WildFly.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_list_recursive_children_of_WildFly.yml
@@ -31,7 +31,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:40 GMT
+      - Thu, 05 May 2016 11:18:42 GMT
       X-Total-Count:
       - '1'
       Connection:
@@ -39,7 +39,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '357'
+      - '351'
       Link:
       - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resourceTypes/WildFly%20Server/resources>;
         rel="current"
@@ -53,11 +53,11 @@ http_interactions:
             "name" : "WildFly Server",
             "id" : "WildFly Server"
           },
-          "name" : "dhcp-10-40-1-43/Local",
+          "name" : "localhost/Local",
           "id" : "Local~~"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:40 GMT
+  recorded_at: Thu, 05 May 2016 11:18:42 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/recursiveChildren
@@ -89,7 +89,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:40 GMT
+      - Thu, 05 May 2016 11:18:43 GMT
       X-Total-Count:
       - '251'
       Connection:
@@ -2365,5 +2365,5 @@ http_interactions:
           "id" : "Local~/deployment=hawkular-commons-embedded-cassandra-ear.ear/subdeployment=hawkular-commons-embedded-cassandra-service-0.4.0.Final.jar/subsystem=ejb3/singleton-bean=EmbeddedCassandraService"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:40 GMT
+  recorded_at: Thu, 05 May 2016 11:18:43 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_list_relationships_of_WildFly.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_list_relationships_of_WildFly.yml
@@ -31,7 +31,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:40 GMT
+      - Thu, 05 May 2016 11:18:43 GMT
       X-Total-Count:
       - '1'
       Connection:
@@ -39,7 +39,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '357'
+      - '351'
       Link:
       - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resourceTypes/WildFly%20Server/resources>;
         rel="current"
@@ -53,14 +53,14 @@ http_interactions:
             "name" : "WildFly Server",
             "id" : "WildFly Server"
           },
-          "name" : "dhcp-10-40-1-43/Local",
+          "name" : "localhost/Local",
           "id" : "Local~~"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:40 GMT
+  recorded_at: Thu, 05 May 2016 11:18:43 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/relationships
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/relationships?sort=__targetCp
     body:
       encoding: US-ASCII
       string: ''
@@ -89,7 +89,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:40 GMT
+      - Thu, 05 May 2016 11:18:43 GMT
       X-Total-Count:
       - '61'
       Connection:
@@ -99,74 +99,214 @@ http_interactions:
       Content-Length:
       - '20294'
       Link:
-      - <http://localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/relationships>;
+      - <http://localhost:8080/hawkular/inventory/path/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/relationships?sort=__targetCp>;
         rel="current"
     body:
       encoding: ASCII-8BIT
       string: |-
         [ {
+          "id" : "ax7k-9a8-1d05-1jwg",
+          "name" : "incorporates",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;AI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~AT~Server%20Availability~App%20Server"
+        }, {
+          "id" : "ax6o-9a8-1d05-1jpc",
+          "name" : "incorporates",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions"
+        }, {
+          "id" : "ax5s-9a8-1d05-1ji8",
+          "name" : "incorporates",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions"
+        }, {
+          "id" : "ax1c-9a8-1d05-1iio",
+          "name" : "incorporates",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions"
+        }, {
+          "id" : "ax40-9a8-1d05-1j40",
+          "name" : "incorporates",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions"
+        }, {
+          "id" : "awyo-9a8-1d05-1hxc",
+          "name" : "incorporates",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count"
+        }, {
+          "id" : "awww-9a8-1d05-1hj4",
+          "name" : "incorporates",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time"
+        }, {
+          "id" : "aww0-9a8-1d05-1hc0",
+          "name" : "incorporates",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration"
+        }, {
+          "id" : "ax28-9a8-1d05-1ips",
+          "name" : "incorporates",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed"
+        }, {
+          "id" : "ax34-9a8-1d05-1iww",
+          "name" : "incorporates",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max"
+        }, {
+          "id" : "awxs-9a8-1d05-1hq8",
+          "name" : "incorporates",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used"
+        }, {
+          "id" : "ax0g-9a8-1d05-1ibk",
+          "name" : "incorporates",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed"
+        }, {
+          "id" : "awzk-9a8-1d05-1i4g",
+          "name" : "incorporates",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used"
+        }, {
+          "id" : "ax4w-9a8-1d05-1jb4",
+          "name" : "incorporates",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count"
+        }, {
           "id" : "h5s-3k0-1g5x-9a8",
           "name" : "defines",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/rt;WildFly%20Server",
           "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~"
         }, {
-          "id" : "axeo-9a8-1hqt-c0sg",
-          "name" : "isParentOf",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS"
+          "id" : "h4w-1s0-153p-9a8",
+          "name" : "contains",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~"
         }, {
-          "id" : "axls-9a8-1hqt-c0zk",
-          "name" : "isParentOf",
+          "id" : "avwg-9a8-153p-bzeo",
+          "name" : "contains",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DKeycloakDS"
-        }, {
-          "id" : "axsw-9a8-1hqt-c16o",
-          "name" : "isParentOf",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2"
-        }, {
-          "id" : "ay00-9a8-1hqt-c1ds",
-          "name" : "isParentOf",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war"
-        }, {
-          "id" : "ay74-9a8-1hqt-c1kw",
-          "name" : "isParentOf",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war"
-        }, {
-          "id" : "aye8-9a8-1hqt-c1s0",
-          "name" : "isParentOf",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war"
-        }, {
-          "id" : "aylc-9a8-1hqt-c1z4",
-          "name" : "isParentOf",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-avail-creator.war"
-        }, {
-          "id" : "aysg-9a8-1hqt-c268",
-          "name" : "isParentOf",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dsecret-store.war"
-        }, {
-          "id" : "ayzk-9a8-1hqt-c2dc",
-          "name" : "isParentOf",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war"
-        }, {
-          "id" : "az6o-9a8-1hqt-c2kg",
-          "name" : "isParentOf",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war"
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/d;configuration"
         }, {
           "id" : "azds-9a8-1hqt-c2rk",
           "name" : "isParentOf",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
           "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-accounts-events-backend.war"
         }, {
+          "id" : "azc0-9a8-153p-c2rk",
+          "name" : "contains",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-accounts-events-backend.war"
+        }, {
+          "id" : "b0dc-9a8-1hqt-c3r4",
+          "name" : "isParentOf",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-accounts.war"
+        }, {
+          "id" : "b0bk-9a8-153p-c3r4",
+          "name" : "contains",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-accounts.war"
+        }, {
+          "id" : "ay74-9a8-1hqt-c1kw",
+          "name" : "isParentOf",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war"
+        }, {
+          "id" : "ay5c-9a8-153p-c1kw",
+          "name" : "contains",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war"
+        }, {
+          "id" : "az6o-9a8-1hqt-c2kg",
+          "name" : "isParentOf",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war"
+        }, {
+          "id" : "az4w-9a8-153p-c2kg",
+          "name" : "contains",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war"
+        }, {
+          "id" : "aylc-9a8-1hqt-c1z4",
+          "name" : "isParentOf",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-avail-creator.war"
+        }, {
+          "id" : "ayjk-9a8-153p-c1z4",
+          "name" : "contains",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-avail-creator.war"
+        }, {
+          "id" : "b0kg-9a8-1hqt-c3y8",
+          "name" : "isParentOf",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-btm-server.war"
+        }, {
+          "id" : "b0io-9a8-153p-c3y8",
+          "name" : "contains",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-btm-server.war"
+        }, {
+          "id" : "ay00-9a8-1hqt-c1ds",
+          "name" : "isParentOf",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war"
+        }, {
+          "id" : "axy8-9a8-153p-c1ds",
+          "name" : "contains",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war"
+        }, {
+          "id" : "b068-9a8-1hqt-c3k0",
+          "name" : "isParentOf",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-commons-embedded-cassandra-ear.ear"
+        }, {
+          "id" : "b04g-9a8-153p-c3k0",
+          "name" : "contains",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-commons-embedded-cassandra-ear.ear"
+        }, {
+          "id" : "b0yo-9a8-1hqt-c4cg",
+          "name" : "isParentOf",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-console.war"
+        }, {
+          "id" : "b0ww-9a8-153p-c4cg",
+          "name" : "contains",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-console.war"
+        }, {
+          "id" : "ayzk-9a8-1hqt-c2dc",
+          "name" : "isParentOf",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war"
+        }, {
+          "id" : "ayxs-9a8-153p-c2dc",
+          "name" : "contains",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war"
+        }, {
+          "id" : "azz4-9a8-1hqt-c3cw",
+          "name" : "isParentOf",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war"
+        }, {
+          "id" : "azxc-9a8-153p-c3cw",
+          "name" : "contains",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war"
+        }, {
           "id" : "azkw-9a8-1hqt-c2yo",
           "name" : "isParentOf",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-pinger.war"
+        }, {
+          "id" : "azj4-9a8-153p-c2yo",
+          "name" : "contains",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
           "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-pinger.war"
         }, {
@@ -175,241 +315,101 @@ http_interactions:
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
           "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war"
         }, {
-          "id" : "azz4-9a8-1hqt-c3cw",
-          "name" : "isParentOf",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war"
-        }, {
-          "id" : "b068-9a8-1hqt-c3k0",
-          "name" : "isParentOf",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-commons-embedded-cassandra-ear.ear"
-        }, {
-          "id" : "b0dc-9a8-1hqt-c3r4",
-          "name" : "isParentOf",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-accounts.war"
-        }, {
-          "id" : "b0kg-9a8-1hqt-c3y8",
-          "name" : "isParentOf",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-btm-server.war"
-        }, {
-          "id" : "b0rk-9a8-1hqt-c45c",
-          "name" : "isParentOf",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dkeycloak-server.war"
-        }, {
-          "id" : "b0yo-9a8-1hqt-c4cg",
-          "name" : "isParentOf",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-console.war"
-        }, {
-          "id" : "b15s-9a8-1hqt-c4jk",
-          "name" : "isParentOf",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Dtransactions"
-        }, {
-          "id" : "b1cw-9a8-1hqt-c4qo",
-          "name" : "isParentOf",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault"
-        }, {
-          "id" : "b1k0-9a8-1hqt-c4xs",
-          "name" : "isParentOf",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Dhawkular-wildfly-agent"
-        }, {
-          "id" : "avwg-9a8-153p-bzeo",
+          "id" : "azq8-9a8-153p-c35s",
           "name" : "contains",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/d;configuration"
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war"
         }, {
-          "id" : "axcw-9a8-153p-c0sg",
-          "name" : "contains",
+          "id" : "aye8-9a8-1hqt-c1s0",
+          "name" : "isParentOf",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS"
-        }, {
-          "id" : "axk0-9a8-153p-c0zk",
-          "name" : "contains",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DKeycloakDS"
-        }, {
-          "id" : "axr4-9a8-153p-c16o",
-          "name" : "contains",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2"
-        }, {
-          "id" : "axy8-9a8-153p-c1ds",
-          "name" : "contains",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-command-gateway-war.war"
-        }, {
-          "id" : "ay5c-9a8-153p-c1kw",
-          "name" : "contains",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war"
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war"
         }, {
           "id" : "aycg-9a8-153p-c1s0",
           "name" : "contains",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
           "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war"
         }, {
-          "id" : "ayjk-9a8-153p-c1z4",
-          "name" : "contains",
+          "id" : "b0rk-9a8-1hqt-c45c",
+          "name" : "isParentOf",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-avail-creator.war"
-        }, {
-          "id" : "ayqo-9a8-153p-c268",
-          "name" : "contains",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dsecret-store.war"
-        }, {
-          "id" : "ayxs-9a8-153p-c2dc",
-          "name" : "contains",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-inventory-dist.war"
-        }, {
-          "id" : "az4w-9a8-153p-c2kg",
-          "name" : "contains",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-rest.war"
-        }, {
-          "id" : "azc0-9a8-153p-c2rk",
-          "name" : "contains",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-accounts-events-backend.war"
-        }, {
-          "id" : "azj4-9a8-153p-c2yo",
-          "name" : "contains",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-pinger.war"
-        }, {
-          "id" : "azq8-9a8-153p-c35s",
-          "name" : "contains",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-rest-api.war"
-        }, {
-          "id" : "azxc-9a8-153p-c3cw",
-          "name" : "contains",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-metrics-component.war"
-        }, {
-          "id" : "b04g-9a8-153p-c3k0",
-          "name" : "contains",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-commons-embedded-cassandra-ear.ear"
-        }, {
-          "id" : "b0bk-9a8-153p-c3r4",
-          "name" : "contains",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-accounts.war"
-        }, {
-          "id" : "b0io-9a8-153p-c3y8",
-          "name" : "contains",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-btm-server.war"
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dkeycloak-server.war"
         }, {
           "id" : "b0ps-9a8-153p-c45c",
           "name" : "contains",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
           "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dkeycloak-server.war"
         }, {
-          "id" : "b0ww-9a8-153p-c4cg",
-          "name" : "contains",
+          "id" : "aysg-9a8-1hqt-c268",
+          "name" : "isParentOf",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-console.war"
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dsecret-store.war"
         }, {
-          "id" : "b140-9a8-153p-c4jk",
+          "id" : "ayqo-9a8-153p-c268",
           "name" : "contains",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Dtransactions"
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fdeployment%3Dsecret-store.war"
         }, {
-          "id" : "b1b4-9a8-153p-c4qo",
+          "id" : "axeo-9a8-1hqt-c0sg",
+          "name" : "isParentOf",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS"
+        }, {
+          "id" : "axcw-9a8-153p-c0sg",
           "name" : "contains",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault"
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS"
+        }, {
+          "id" : "axls-9a8-1hqt-c0zk",
+          "name" : "isParentOf",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DKeycloakDS"
+        }, {
+          "id" : "axk0-9a8-153p-c0zk",
+          "name" : "contains",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DKeycloakDS"
+        }, {
+          "id" : "axsw-9a8-1hqt-c16o",
+          "name" : "isParentOf",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2"
+        }, {
+          "id" : "axr4-9a8-153p-c16o",
+          "name" : "contains",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fjdbc-driver%3Dh2"
+        }, {
+          "id" : "b1k0-9a8-1hqt-c4xs",
+          "name" : "isParentOf",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Dhawkular-wildfly-agent"
         }, {
           "id" : "b1i8-9a8-153p-c4xs",
           "name" : "contains",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
           "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Dhawkular-wildfly-agent"
         }, {
-          "id" : "h4w-1s0-153p-9a8",
+          "id" : "b1cw-9a8-1hqt-c4qo",
+          "name" : "isParentOf",
+          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault"
+        }, {
+          "id" : "b1b4-9a8-153p-c4qo",
           "name" : "contains",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~"
-        }, {
-          "id" : "aww0-9a8-1d05-1hc0",
-          "name" : "incorporates",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Committed"
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Dmessaging-activemq%2Fserver%3Ddefault"
         }, {
-          "id" : "awww-9a8-1d05-1hj4",
-          "name" : "incorporates",
+          "id" : "b15s-9a8-1hqt-c4jk",
+          "name" : "isParentOf",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Count"
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Dtransactions"
         }, {
-          "id" : "awxs-9a8-1d05-1hq8",
-          "name" : "incorporates",
+          "id" : "b140-9a8-153p-c4jk",
+          "name" : "contains",
           "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Active%20Web%20Sessions"
-        }, {
-          "id" : "awyo-9a8-1d05-1hxc",
-          "name" : "incorporates",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~NonHeap%20Used"
-        }, {
-          "id" : "awzk-9a8-1d05-1i4g",
-          "name" : "incorporates",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Committed"
-        }, {
-          "id" : "ax0g-9a8-1d05-1ibk",
-          "name" : "incorporates",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Max"
-        }, {
-          "id" : "ax1c-9a8-1d05-1iio",
-          "name" : "incorporates",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Threading%20Metrics~Thread%20Count"
-        }, {
-          "id" : "ax28-9a8-1d05-1ips",
-          "name" : "incorporates",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Accumulated%20GC%20Duration"
-        }, {
-          "id" : "ax34-9a8-1d05-1iww",
-          "name" : "incorporates",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Expired%20Web%20Sessions"
-        }, {
-          "id" : "ax40-9a8-1d05-1j40",
-          "name" : "incorporates",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Memory%20Metrics~Heap%20Used"
-        }, {
-          "id" : "ax4w-9a8-1d05-1jb4",
-          "name" : "incorporates",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Servlet%20Request%20Time"
-        }, {
-          "id" : "ax5s-9a8-1d05-1ji8",
-          "name" : "incorporates",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Rejected%20Web%20Sessions"
-        }, {
-          "id" : "ax6o-9a8-1d05-1jpc",
-          "name" : "incorporates",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;MI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~MT~WildFly%20Aggregated%20Web%20Metrics~Aggregated%20Max%20Active%20Web%20Sessions"
-        }, {
-          "id" : "ax7k-9a8-1d05-1jwg",
-          "name" : "incorporates",
-          "source" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
-          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/m;AI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~AT~Server%20Availability~App%20Server"
+          "target" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Dtransactions"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:40 GMT
+  recorded_at: Thu, 05 May 2016 11:18:43 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_list_types_with_bad_feed.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_list_types_with_bad_feed.yml
@@ -31,7 +31,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:39 GMT
+      - Thu, 05 May 2016 11:18:41 GMT
       X-Total-Count:
       - "-1"
       Connection:
@@ -47,5 +47,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "[ ]"
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:39 GMT
+  recorded_at: Thu, 05 May 2016 11:18:41 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_list_types_with_feed.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_list_types_with_feed.yml
@@ -31,7 +31,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:39 GMT
+      - Thu, 05 May 2016 11:18:41 GMT
       X-Total-Count:
       - '18'
       Connection:
@@ -120,5 +120,5 @@ http_interactions:
           "id" : "Hawkular WildFly Agent"
         } ]
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:39 GMT
+  recorded_at: Thu, 05 May 2016 11:18:41 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_not_find_an_unknown_resource.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_not_find_an_unknown_resource.yml
@@ -31,7 +31,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 11 Apr 2016 16:51:45 GMT
+      - Thu, 05 May 2016 11:18:48 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -51,5 +51,5 @@ http_interactions:
           }
         }
     http_version: 
-  recorded_at: Mon, 11 Apr 2016 16:51:45 GMT
+  recorded_at: Thu, 05 May 2016 11:18:48 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_return_config_data_of_given_nested_resource.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_return_config_data_of_given_nested_resource.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/Local~%2Fsubsystem=datasources%2Fdata-source=ExampleDS/data?dataType=configuration
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 05 May 2016 11:18:44 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '462'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/r;Local~%2Fsubsystem%3Ddatasources%2Fdata-source%3DExampleDS/d;configuration",
+          "value" : {
+            "Username" : "sa",
+            "Driver Name" : "h2",
+            "JNDI Name" : "java:jboss/datasources/ExampleDS",
+            "Connection URL" : "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+            "Enabled" : "true",
+            "Password" : "sa"
+          },
+          "name" : "configuration"
+        }
+    http_version: 
+  recorded_at: Thu, 05 May 2016 11:18:44 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_return_config_data_of_given_resource.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_return_config_data_of_given_resource.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~/data?dataType=configuration
     body:
       encoding: US-ASCII
       string: ''
@@ -31,24 +31,27 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Thu, 05 May 2016 11:18:36 GMT
-      X-Total-Count:
-      - '1'
+      - Thu, 05 May 2016 11:18:44 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '148'
-      Link:
-      - <http://localhost:8080/hawkular/inventory/feeds>; rel="current"
+      - '351'
     body:
       encoding: ASCII-8BIT
       string: |-
-        [ {
-          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;5958668a-b073-4098-b265-587b45c659ee",
-          "id" : "5958668a-b073-4098-b265-587b45c659ee"
-        } ]
+        {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~/d;configuration",
+          "value" : {
+            "Bound Address" : "127.0.0.1",
+            "Version" : "1.0.0.Alpha13-SNAPSHOT",
+            "Server State" : "running",
+            "Product Name" : "Hawkular",
+            "Hostname" : "localhost.localdomain"
+          },
+          "name" : "configuration"
+        }
     http_version: 
-  recorded_at: Thu, 05 May 2016 11:18:36 GMT
+  recorded_at: Thu, 05 May 2016 11:18:44 GMT
 recorded_with: VCR 3.0.1


### PR DESCRIPTION
This is basically the same PR as the #55 but now targeting directly the master branch (not the 0.3.0 integration branch). It is based on PR #49 

It should fix the Issue #54 

All the methods dealing with resources expected the flat structure, but resources can be nested, so instead of `resource_id` as identifier we now use an array of those ids.
