### PR TITLE
Add support for group triggers

### DIFF
--- a/lib/hawkular/alerts/alerts_api.rb
+++ b/lib/hawkular/alerts/alerts_api.rb
@@ -360,7 +360,7 @@ module Hawkular::Alerts
     # Representing of one Condition
     class Condition
       attr_accessor :condition_id, :type, :operator, :threshold
-      attr_accessor :trigger_mode, :data_id
+      attr_accessor :trigger_mode, :data_id, :data2_id, :data2_multiplier
       attr_reader :condition_set_size, :condition_set_index, :trigger_id
 
       def initialize(cond_hash)
@@ -371,6 +371,8 @@ module Hawkular::Alerts
         @type = cond_hash['type']
         @trigger_mode = cond_hash['triggerMode']
         @data_id = cond_hash['dataId']
+        @data2_id = cond_hash['data2Id']
+        @data2_multiplier = cond_hash['data2Multiplier']
         @trigger_id = cond_hash['triggerId']
       end
 
@@ -383,6 +385,8 @@ module Hawkular::Alerts
         cond_hash['type'] = @type
         cond_hash['triggerMode'] = @trigger_mode
         cond_hash['dataId'] = @data_id
+        cond_hash['data2Id'] = @data2_id
+        cond_hash['data2Multiplier'] = @data2_multiplier
         cond_hash['triggerId'] = @trigger_id
         cond_hash
       end

--- a/lib/hawkular/alerts/alerts_api.rb
+++ b/lib/hawkular/alerts/alerts_api.rb
@@ -81,10 +81,93 @@ module Hawkular::Alerts
       http_post 'triggers/trigger', full_trigger
     end
 
+    # Creates the group trigger definition.
+    # @param [Trigger] trigger The group trigger to be created
+    # @return [Trigger] The newly created group trigger
+    def create_group_trigger(trigger)
+      ret = http_post 'triggers/groups', trigger.to_h
+      Trigger.new(ret)
+    end
+
+    # Updates a given group trigger definition
+    # @param [Trigger] trigger the group trigger to be updated
+    # @return [Trigger] The updated group trigger
+    def update_group_trigger(trigger)
+      http_put "triggers/groups/#{trigger.id}/", trigger.to_h
+      get_single_trigger trigger.id, false
+    end
+
+    # Creates the group conditions definitions.
+    # @param [String] trigger_id ID of the group trigger to set conditions
+    # @param [String] trigger_mode Mode of the trigger where conditions are attached (:FIRING, :AUTORESOLVE)
+    # @param [GroupConditionsInfo] group_conditions_info the conditions to set into the group trigger with the mapping
+    #                                                    with the data_id members map
+    # @return [Array<Condition>] conditions Array of associated conditions
+    def set_group_conditions(trigger_id, trigger_mode, group_conditions_info)
+      ret = http_put "triggers/groups/#{trigger_id}/conditions/#{trigger_mode}", group_conditions_info.to_h
+      conditions = []
+      ret.each { |c| conditions.push(Trigger::Condition.new(c)) }
+      conditions
+    end
+
+    # Creates a member trigger
+    # @param [GroupMemberInfo] group_member_info the group member to be added
+    # @return [Trigger] the newly created member trigger
+    def create_member_trigger(group_member_info)
+      ret = http_post 'triggers/groups/members', group_member_info.to_h
+      Trigger.new(ret)
+    end
+
+    # Detaches a member trigger from its group trigger
+    # @param [String] trigger_id ID of the member trigger to detach
+    # @return [Trigger] the orphan trigger
+    def orphan_member(trigger_id)
+      http_post "triggers/groups/members/#{trigger_id}/orphan", {}
+      get_single_trigger trigger_id, false
+    end
+
+    # Lists members of a group trigger
+    # @param [String] trigger_id ID of the group trigger to list members
+    # @param [boolean] orphans flag to include orphans
+    # @return [Array<Trigger>] Members found
+    def list_members(trigger_id, orphans = false)
+      ret = http_get "triggers/groups/#{trigger_id}/members?includeOrphans=#{orphans}"
+      ret.collect { |t| Trigger.new(t) }
+    end
+
+    # Creates a dampening for a group trigger
+    # @param [Dampening] dampening the dampening to create
+    # @return [Dampening] the newly created dampening
+    def create_group_dampening(dampening)
+      ret = http_post "triggers/groups/#{dampening.trigger_id}/dampenings", dampening.to_h
+      Trigger::Dampening.new(ret)
+    end
+
+    # Updates a dampening for a group trigger
+    # @param [Dampening] dampening the dampening to update
+    # @return [Dampening] the updated dampening
+    def update_group_dampening(dampening)
+      ret = http_put "triggers/groups/#{dampening.trigger_id}/dampenings/#{dampening.dampening_id}", dampening.to_h
+      Trigger::Dampening.new(ret)
+    end
+
+    # Deletes the dampening of a group trigger
+    # @param [String] trigger_id ID of the group trigger
+    # @param [String] dampening_id ID
+    def delete_group_dampening(trigger_id, dampening_id)
+      http_delete "/triggers/groups/#{trigger_id}/dampenings/#{dampening_id}"
+    end
+
     # Deletes the trigger definition.
-    # @param [String] trigger_id Id of the trigger to delete
+    # @param [String] trigger_id ID of the trigger to delete
     def delete_trigger(trigger_id)
       http_delete "/triggers/#{trigger_id}"
+    end
+
+    # Deletes the group trigger definition.
+    # @param [String] trigger_id ID of the group trigger to delete
+    def delete_group_trigger(trigger_id)
+      http_delete "/triggers/groups/#{trigger_id}"
     end
 
     # Obtains action definition/plugin from the server.
@@ -220,7 +303,7 @@ module Hawkular::Alerts
   class Trigger
     attr_accessor :id, :name, :context, :actions, :auto_disable, :auto_enable
     attr_accessor :auto_resolve, :auto_resolve_alerts, :tags, :type
-    attr_accessor :tenant, :description, :group, :severity, :event_type
+    attr_accessor :tenant, :description, :group, :severity, :event_type, :event_category, :member_of, :data_id_map
     attr_reader :conditions, :dampenings
     attr_accessor :enabled, :actions
 
@@ -238,6 +321,9 @@ module Hawkular::Alerts
       @auto_resolve = trigger_hash['autoResolve']
       @auto_resolve_alerts = trigger_hash['autoResolveAlerts']
       @event_type = trigger_hash['eventType']
+      @event_category = trigger_hash['eventCategory']
+      @member_of = trigger_hash['memberOf']
+      @data_id_map = trigger_hash['dataIdMap']
       @tenant = trigger_hash['tenantId']
       @description = trigger_hash['description']
       @auto_enable = trigger_hash['autoEnable']
@@ -255,8 +341,8 @@ module Hawkular::Alerts
         ret = x.to_s.split('_').collect(&:capitalize).join
         ret[0, 1].downcase + ret[1..-1]
       end
-      fields = [:id, :name, :enabled, :severity, :auto_resolve, :auto_resolve_alerts, :event_type,
-                :description, :auto_enable, :auto_disable, :context, :type, :tags]
+      fields = [:id, :name, :enabled, :severity, :auto_resolve, :auto_resolve_alerts, :event_type, :event_category,
+                :description, :auto_enable, :auto_disable, :context, :type, :tags, :member_of, :data_id_map]
 
       fields.each do |field|
         camelized_field = to_camel.call(field)
@@ -302,19 +388,74 @@ module Hawkular::Alerts
       end
     end
 
+    # Representing of one GroupConditionsInfo
+    # - The data_id_member_map should be null if the group has no members.
+    # - The data_id_member_map should be null if this is a [data-driven] group trigger.
+    #   In this case the member triggers are removed and will be re-populated as incoming data demands.
+    # - For [non-data-driven] group triggers with existing members the data_id_member_map is handled as follows.
+    #   For members not included in the dataIdMemberMap their most recently supplied dataIdMap will be used.
+    #   This means that it is not necessary to supply mappings if the new condition set uses only dataIds found
+    #   in the old condition set. If the new conditions introduce new dataIds a full dataIdMemberMap must be supplied.
+    class GroupConditionsInfo
+      attr_accessor :conditions, :data_id_member_map
+
+      def initialize(conditions)
+        @conditions = conditions
+        @data_id_member_map = {}
+      end
+
+      def to_h
+        cond_hash = {}
+        cond_hash['conditions'] = []
+        @conditions.each { |c| cond_hash['conditions'].push(c.to_h) }
+        cond_hash['dataIdMemberMap'] = @data_id_member_map
+        cond_hash
+      end
+    end
+
+    # Representing of one GroupMemberInfo
+    class GroupMemberInfo
+      attr_accessor :group_id, :member_id, :member_name, :member_description
+      attr_accessor :member_context, :member_tags, :data_id_map
+
+      def to_h
+        cond_hash = {}
+        cond_hash['groupId'] = @group_id
+        cond_hash['memberId'] = @member_id
+        cond_hash['memberName'] = @member_name
+        cond_hash['memberDescription'] = @member_description
+        cond_hash['memberContext'] = @member_context
+        cond_hash['memberTags'] = @member_tags
+        cond_hash['dataIdMap'] = @data_id_map
+        cond_hash
+      end
+    end
+
     # Representation of one Dampening setting
     class Dampening
-      attr_accessor :dampening_id, :type, :eval_true_setting, :eval_total_setting,
+      attr_accessor :dampening_id, :trigger_id, :type, :eval_true_setting, :eval_total_setting,
                     :eval_time_setting
       attr_accessor :current_evals
 
       def initialize(damp_hash)
         @current_evals = {}
         @dampening_id = damp_hash['dampeningId']
+        @trigger_id = damp_hash['triggerId']
         @type = damp_hash['type']
         @eval_true_setting = damp_hash['evalTrueSetting']
         @eval_total_setting = damp_hash['evalTotalSetting']
         @eval_time_setting = damp_hash['evalTimeSetting']
+      end
+
+      def to_h
+        cond_hash = {}
+        cond_hash['dampeningId'] = @dampening_id
+        cond_hash['triggerId'] = @trigger_id
+        cond_hash['type'] = @type
+        cond_hash['evalTrueSetting'] = @eval_true_setting
+        cond_hash['evalTotalSetting'] = @eval_total_setting
+        cond_hash['evalTimeSetting'] = @eval_time_setting
+        cond_hash
       end
     end
 

--- a/spec/vcr_cassettes/Alert/Groups/Should_operate_a_complex_group_trigger.yml
+++ b/spec/vcr_cassettes/Alert/Groups/Should_operate_a_complex_group_trigger.yml
@@ -34,7 +34,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:45 GMT
+      - Fri, 06 May 2016 13:28:05 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -46,13 +46,13 @@ http_interactions:
       string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"a-group-trigger","name":"A
         Group Trigger","description":"A Group Trigger generated from test","type":"GROUP","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":false,"firingMatch":"ALL","source":"_none_"}'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:45 GMT
+  recorded_at: Fri, 06 May 2016 13:28:05 GMT
 - request:
     method: put
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/conditions/FIRING
     body:
       encoding: UTF-8
-      string: '{"conditions":[{"conditionId":null,"type":"THRESHOLD","operator":"LT","threshold":5,"triggerMode":"FIRING","dataId":"my-metric-id","triggerId":null}],"dataIdMemberMap":{}}'
+      string: '{"conditions":[{"conditionId":null,"type":"THRESHOLD","operator":"LT","threshold":5,"triggerMode":"FIRING","dataId":"my-metric-id","data2Id":null,"data2Multiplier":null,"triggerId":null}],"dataIdMemberMap":{}}'
     headers:
       Accept:
       - application/json
@@ -61,7 +61,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '171'
+      - '209'
       User-Agent:
       - Ruby
   response:
@@ -80,7 +80,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:45 GMT
+      - Fri, 06 May 2016 13:28:05 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -91,7 +91,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"a-group-trigger","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":1,"conditionSetIndex":1,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-a-group-trigger-FIRING-1-1","dataId":"my-metric-id","operator":"LT","threshold":5.0}]'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:45 GMT
+  recorded_at: Fri, 06 May 2016 13:28:05 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/members
@@ -126,7 +126,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:45 GMT
+      - Fri, 06 May 2016 13:28:05 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -138,7 +138,7 @@ http_interactions:
       string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
         One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:45 GMT
+  recorded_at: Fri, 06 May 2016 13:28:05 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1
@@ -170,7 +170,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:45 GMT
+      - Fri, 06 May 2016 13:28:05 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -182,7 +182,7 @@ http_interactions:
       string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
         One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:45 GMT
+  recorded_at: Fri, 06 May 2016 13:28:05 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1/conditions
@@ -214,7 +214,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:45 GMT
+      - Fri, 06 May 2016 13:28:05 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -225,7 +225,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":1,"conditionSetIndex":1,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING-1-1","dataId":"my-metric-id-member1","operator":"LT","threshold":5.0}]'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:45 GMT
+  recorded_at: Fri, 06 May 2016 13:28:05 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1/dampenings
@@ -257,7 +257,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:45 GMT
+      - Fri, 06 May 2016 13:28:05 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -268,7 +268,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:45 GMT
+  recorded_at: Fri, 06 May 2016 13:28:05 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/members?includeOrphans=false
@@ -300,7 +300,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:05 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -312,7 +312,7 @@ http_interactions:
       string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
         One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}]'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:05 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/members
@@ -347,7 +347,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:05 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -359,7 +359,7 @@ http_interactions:
       string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member2","name":"Member
         Two","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member2"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:05 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member2
@@ -391,7 +391,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:05 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -403,7 +403,7 @@ http_interactions:
       string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member2","name":"Member
         Two","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member2"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:05 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member2/conditions
@@ -435,7 +435,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:05 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -446,7 +446,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member2","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":1,"conditionSetIndex":1,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-member2-FIRING-1-1","dataId":"my-metric-id-member2","operator":"LT","threshold":5.0}]'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:05 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member2/dampenings
@@ -478,7 +478,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:05 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -489,7 +489,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:05 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/members?includeOrphans=false
@@ -521,7 +521,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:05 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -534,7 +534,7 @@ http_interactions:
         One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"},{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member2","name":"Member
         Two","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member2"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}]'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:05 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/members/member2/orphan
@@ -568,7 +568,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:05 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -579,7 +579,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:05 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member2
@@ -611,7 +611,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:05 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -623,7 +623,7 @@ http_interactions:
       string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member2","name":"Member
         Two","description":"A Group Trigger generated from test","type":"ORPHAN","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member2"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:05 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/members?includeOrphans=false
@@ -655,7 +655,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:05 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -667,7 +667,7 @@ http_interactions:
       string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
         One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}]'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:05 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/members?includeOrphans=true
@@ -699,7 +699,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:05 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -712,7 +712,7 @@ http_interactions:
         One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"},{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member2","name":"Member
         Two","description":"A Group Trigger generated from test","type":"ORPHAN","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member2"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}]'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:05 GMT
 - request:
     method: post
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/dampenings
@@ -746,7 +746,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:05 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -757,7 +757,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"a-group-trigger","triggerMode":"FIRING","type":"STRICT","evalTrueSetting":2,"evalTotalSetting":2,"evalTimeSetting":0,"dampeningId":"28026b36-8fe4-4332-84c8-524e173a68bf-a-group-trigger-FIRING"}'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:05 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1
@@ -789,7 +789,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:06 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -801,7 +801,7 @@ http_interactions:
       string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
         One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1/conditions
@@ -833,7 +833,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:06 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -844,7 +844,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":1,"conditionSetIndex":1,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING-1-1","dataId":"my-metric-id-member1","operator":"LT","threshold":5.0}]'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1/dampenings
@@ -876,7 +876,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:06 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -887,7 +887,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"STRICT","evalTrueSetting":2,"evalTotalSetting":2,"evalTimeSetting":0,"dampeningId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING"}]'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
 - request:
     method: put
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/
@@ -922,7 +922,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:06 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -933,7 +933,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/a-group-trigger
@@ -965,7 +965,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:06 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -977,7 +977,7 @@ http_interactions:
       string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"a-group-trigger","name":"A
         Group Trigger","description":"A Group Trigger generated from test","type":"GROUP","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","tags":{"group-tname":"group-tvalue"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":false,"firingMatch":"ALL","source":"_none_"}'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1
@@ -1009,7 +1009,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:06 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1021,13 +1021,13 @@ http_interactions:
       string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
         One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","tags":{"group-tname":"group-tvalue"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
 - request:
     method: put
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/conditions/FIRING
     body:
       encoding: UTF-8
-      string: '{"conditions":[{"conditionId":null,"type":"THRESHOLD","operator":"LT","threshold":5,"triggerMode":"FIRING","dataId":"my-metric-id","triggerId":null},{"conditionId":null,"type":"THRESHOLD","operator":"GT","threshold":50,"triggerMode":"FIRING","dataId":"my-metric-id2","triggerId":null}],"dataIdMemberMap":{"my-metric-id":{"member1":"my-metric-id-member1"},"my-metric-id2":{"member1":"my-metric-id2-member1"}}}'
+      string: '{"conditions":[{"conditionId":null,"type":"THRESHOLD","operator":"LT","threshold":5,"triggerMode":"FIRING","dataId":"my-metric-id","data2Id":null,"data2Multiplier":null,"triggerId":null},{"conditionId":null,"type":"THRESHOLD","operator":"GT","threshold":50,"triggerMode":"FIRING","dataId":"my-metric-id2","data2Id":null,"data2Multiplier":null,"triggerId":null}],"dataIdMemberMap":{"my-metric-id":{"member1":"my-metric-id-member1"},"my-metric-id2":{"member1":"my-metric-id2-member1"}}}'
     headers:
       Accept:
       - application/json
@@ -1036,7 +1036,7 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '408'
+      - '484'
       User-Agent:
       - Ruby
   response:
@@ -1055,7 +1055,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:06 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1066,7 +1066,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"a-group-trigger","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":2,"conditionSetIndex":1,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-a-group-trigger-FIRING-2-1","dataId":"my-metric-id","operator":"LT","threshold":5.0},{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"a-group-trigger","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":2,"conditionSetIndex":2,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-a-group-trigger-FIRING-2-2","dataId":"my-metric-id2","operator":"GT","threshold":50.0}]'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1
@@ -1098,7 +1098,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:06 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1110,7 +1110,7 @@ http_interactions:
       string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
         One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","tags":{"group-tname":"group-tvalue"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1/conditions
@@ -1142,7 +1142,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:06 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1153,7 +1153,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":2,"conditionSetIndex":1,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING-2-1","dataId":"my-metric-id-member1","operator":"LT","threshold":5.0},{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":2,"conditionSetIndex":2,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING-2-2","dataId":"my-metric-id2-member1","operator":"GT","threshold":50.0}]'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1/dampenings
@@ -1185,7 +1185,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:06 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1196,7 +1196,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"STRICT","evalTrueSetting":2,"evalTotalSetting":2,"evalTimeSetting":0,"dampeningId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING"}]'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
 - request:
     method: put
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/dampenings/28026b36-8fe4-4332-84c8-524e173a68bf-a-group-trigger-FIRING
@@ -1230,7 +1230,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:06 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1241,7 +1241,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"a-group-trigger","triggerMode":"FIRING","type":"RELAXED_COUNT","evalTrueSetting":2,"evalTotalSetting":4,"evalTimeSetting":0,"dampeningId":"28026b36-8fe4-4332-84c8-524e173a68bf-a-group-trigger-FIRING"}'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
 - request:
     method: put
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/
@@ -1276,7 +1276,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:06 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1287,7 +1287,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/a-group-trigger
@@ -1319,7 +1319,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:06 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1331,7 +1331,7 @@ http_interactions:
       string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"a-group-trigger","name":"A
         Group Trigger","description":"A Group Trigger generated from test","type":"GROUP","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","context":{"alert-profiles":"profile1"},"tags":{"group-tname":"group-tvalue"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":false,"firingMatch":"ALL","source":"_none_"}'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
 - request:
     method: delete
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/dampenings/28026b36-8fe4-4332-84c8-524e173a68bf-a-group-trigger-FIRING
@@ -1363,7 +1363,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:06 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1374,7 +1374,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1
@@ -1406,7 +1406,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:06 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1418,7 +1418,7 @@ http_interactions:
       string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
         One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","context":{"alert-profiles":"profile1"},"tags":{"group-tname":"group-tvalue"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1/conditions
@@ -1450,7 +1450,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:06 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1461,7 +1461,7 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":2,"conditionSetIndex":1,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING-2-1","dataId":"my-metric-id-member1","operator":"LT","threshold":5.0},{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":2,"conditionSetIndex":2,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING-2-2","dataId":"my-metric-id2-member1","operator":"GT","threshold":50.0}]'
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1/dampenings
@@ -1493,7 +1493,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:06 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1504,7 +1504,182 @@ http_interactions:
       encoding: ASCII-8BIT
       string: "[]"
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
+- request:
+    method: put
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/conditions/FIRING
+    body:
+      encoding: UTF-8
+      string: '{"conditions":[{"conditionId":null,"type":"THRESHOLD","operator":"LT","threshold":5,"triggerMode":"FIRING","dataId":"my-metric-id","data2Id":null,"data2Multiplier":null,"triggerId":null},{"conditionId":null,"type":"THRESHOLD","operator":"GT","threshold":50,"triggerMode":"FIRING","dataId":"my-metric-id2","data2Id":null,"data2Multiplier":null,"triggerId":null},{"conditionId":null,"type":"COMPARE","operator":"GT","threshold":null,"triggerMode":"FIRING","dataId":"my-metric-id3","data2Id":"my-metric-id4","data2Multiplier":1,"triggerId":null}],"dataIdMemberMap":{"my-metric-id":{"member1":"my-metric-id-member1"},"my-metric-id2":{"member1":"my-metric-id2-member1"},"my-metric-id3":{"member1":"my-metric-id3-member1"},"my-metric-id4":{"member1":"my-metric-id4-member1"}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '770'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 06 May 2016 13:28:06 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '943'
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"a-group-trigger","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":3,"conditionSetIndex":1,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-a-group-trigger-FIRING-3-1","dataId":"my-metric-id","operator":"LT","threshold":5.0},{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"a-group-trigger","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":3,"conditionSetIndex":2,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-a-group-trigger-FIRING-3-2","dataId":"my-metric-id2","operator":"GT","threshold":50.0},{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"a-group-trigger","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":3,"conditionSetIndex":3,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-a-group-trigger-FIRING-3-3","dataId":"my-metric-id3","operator":"GT","data2Id":"my-metric-id4","data2Multiplier":1.0}]'
+    http_version: 
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 06 May 2016 13:28:06 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '552'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
+        One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","context":{"alert-profiles":"profile1"},"tags":{"group-tname":"group-tvalue"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
+    http_version: 
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1/conditions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 06 May 2016 13:28:06 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '927'
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":3,"conditionSetIndex":1,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING-3-1","dataId":"my-metric-id-member1","operator":"LT","threshold":5.0},{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":3,"conditionSetIndex":2,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING-3-2","dataId":"my-metric-id2-member1","operator":"GT","threshold":50.0},{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"COMPARE","conditionSetSize":3,"conditionSetIndex":3,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING-3-3","dataId":"my-metric-id3-member1","operator":"GT","data2Id":"my-metric-id4-member1","data2Multiplier":1.0}]'
+    http_version: 
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1/dampenings
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 06 May 2016 13:28:06 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: ASCII-8BIT
+      string: "[]"
+    http_version: 
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
 - request:
     method: delete
     uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger
@@ -1536,7 +1711,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Wed, 04 May 2016 15:45:46 GMT
+      - Fri, 06 May 2016 13:28:06 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -1547,5 +1722,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+  recorded_at: Fri, 06 May 2016 13:28:06 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Alert/Groups/Should_operate_a_complex_group_trigger.yml
+++ b/spec/vcr_cassettes/Alert/Groups/Should_operate_a_complex_group_trigger.yml
@@ -1,0 +1,1551 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups
+    body:
+      encoding: UTF-8
+      string: '{"id":"a-group-trigger","name":"A Group Trigger","enabled":false,"severity":"HIGH","description":"A
+        Group Trigger generated from test","actions":[]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '148'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:45 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '405'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"a-group-trigger","name":"A
+        Group Trigger","description":"A Group Trigger generated from test","type":"GROUP","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":false,"firingMatch":"ALL","source":"_none_"}'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:45 GMT
+- request:
+    method: put
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/conditions/FIRING
+    body:
+      encoding: UTF-8
+      string: '{"conditions":[{"conditionId":null,"type":"THRESHOLD","operator":"LT","threshold":5,"triggerMode":"FIRING","dataId":"my-metric-id","triggerId":null}],"dataIdMemberMap":{}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '171'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:45 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '304'
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"a-group-trigger","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":1,"conditionSetIndex":1,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-a-group-trigger-FIRING-1-1","dataId":"my-metric-id","operator":"LT","threshold":5.0}]'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:45 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/members
+    body:
+      encoding: UTF-8
+      string: '{"groupId":"a-group-trigger","memberId":"member1","memberName":"Member
+        One","memberDescription":null,"memberContext":null,"memberTags":null,"dataIdMap":{"my-metric-id":"my-metric-id-member1"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '192'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:45 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '474'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
+        One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:45 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:45 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '474'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
+        One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:45 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1/conditions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:45 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '296'
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":1,"conditionSetIndex":1,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING-1-1","dataId":"my-metric-id-member1","operator":"LT","threshold":5.0}]'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:45 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1/dampenings
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:45 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: ASCII-8BIT
+      string: "[]"
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:45 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/members?includeOrphans=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '476'
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
+        One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}]'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/members
+    body:
+      encoding: UTF-8
+      string: '{"groupId":"a-group-trigger","memberId":"member2","memberName":"Member
+        Two","memberDescription":null,"memberContext":null,"memberTags":null,"dataIdMap":{"my-metric-id":"my-metric-id-member2"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '192'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '474'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member2","name":"Member
+        Two","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member2"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '474'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member2","name":"Member
+        Two","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member2"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member2/conditions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '296'
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member2","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":1,"conditionSetIndex":1,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-member2-FIRING-1-1","dataId":"my-metric-id-member2","operator":"LT","threshold":5.0}]'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member2/dampenings
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: ASCII-8BIT
+      string: "[]"
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/members?includeOrphans=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '951'
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
+        One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"},{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member2","name":"Member
+        Two","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member2"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}]'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/members/member2/orphan
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '474'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member2","name":"Member
+        Two","description":"A Group Trigger generated from test","type":"ORPHAN","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member2"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/members?includeOrphans=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '476'
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
+        One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}]'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/members?includeOrphans=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '951'
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
+        One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"},{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member2","name":"Member
+        Two","description":"A Group Trigger generated from test","type":"ORPHAN","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member2"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}]'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/dampenings
+    body:
+      encoding: UTF-8
+      string: '{"dampeningId":null,"triggerId":"a-group-trigger","type":"STRICT","evalTrueSetting":2,"evalTotalSetting":2,"evalTimeSetting":null}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '130'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '257'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"a-group-trigger","triggerMode":"FIRING","type":"STRICT","evalTrueSetting":2,"evalTotalSetting":2,"evalTimeSetting":0,"dampeningId":"28026b36-8fe4-4332-84c8-524e173a68bf-a-group-trigger-FIRING"}'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '474'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
+        One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1/conditions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '296'
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":1,"conditionSetIndex":1,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING-1-1","dataId":"my-metric-id-member1","operator":"LT","threshold":5.0}]'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1/dampenings
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '243'
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"STRICT","evalTrueSetting":2,"evalTotalSetting":2,"evalTimeSetting":0,"dampeningId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING"}]'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: put
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/
+    body:
+      encoding: UTF-8
+      string: '{"id":"a-group-trigger","name":"A Group Trigger","enabled":false,"severity":"HIGH","autoResolve":false,"autoResolveAlerts":true,"eventType":"ALERT","description":"A
+        Group Trigger generated from test","autoEnable":false,"autoDisable":false,"type":"GROUP","tags":{"group-tname":"group-tvalue"},"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","actions":[]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '355'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/a-group-trigger
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '443'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"a-group-trigger","name":"A
+        Group Trigger","description":"A Group Trigger generated from test","type":"GROUP","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","tags":{"group-tname":"group-tvalue"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":false,"firingMatch":"ALL","source":"_none_"}'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '512'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
+        One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","tags":{"group-tname":"group-tvalue"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: put
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/conditions/FIRING
+    body:
+      encoding: UTF-8
+      string: '{"conditions":[{"conditionId":null,"type":"THRESHOLD","operator":"LT","threshold":5,"triggerMode":"FIRING","dataId":"my-metric-id","triggerId":null},{"conditionId":null,"type":"THRESHOLD","operator":"GT","threshold":50,"triggerMode":"FIRING","dataId":"my-metric-id2","triggerId":null}],"dataIdMemberMap":{"my-metric-id":{"member1":"my-metric-id-member1"},"my-metric-id2":{"member1":"my-metric-id2-member1"}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '408'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '609'
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"a-group-trigger","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":2,"conditionSetIndex":1,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-a-group-trigger-FIRING-2-1","dataId":"my-metric-id","operator":"LT","threshold":5.0},{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"a-group-trigger","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":2,"conditionSetIndex":2,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-a-group-trigger-FIRING-2-2","dataId":"my-metric-id2","operator":"GT","threshold":50.0}]'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '512'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
+        One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","tags":{"group-tname":"group-tvalue"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1/conditions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '593'
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":2,"conditionSetIndex":1,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING-2-1","dataId":"my-metric-id-member1","operator":"LT","threshold":5.0},{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":2,"conditionSetIndex":2,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING-2-2","dataId":"my-metric-id2-member1","operator":"GT","threshold":50.0}]'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1/dampenings
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '243'
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"STRICT","evalTrueSetting":2,"evalTotalSetting":2,"evalTimeSetting":0,"dampeningId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING"}]'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: put
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/dampenings/28026b36-8fe4-4332-84c8-524e173a68bf-a-group-trigger-FIRING
+    body:
+      encoding: UTF-8
+      string: '{"dampeningId":"28026b36-8fe4-4332-84c8-524e173a68bf-a-group-trigger-FIRING","triggerId":"a-group-trigger","type":"RELAXED_COUNT","evalTrueSetting":2,"evalTotalSetting":4,"evalTimeSetting":0}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '191'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '264'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"a-group-trigger","triggerMode":"FIRING","type":"RELAXED_COUNT","evalTrueSetting":2,"evalTotalSetting":4,"evalTimeSetting":0,"dampeningId":"28026b36-8fe4-4332-84c8-524e173a68bf-a-group-trigger-FIRING"}'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: put
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/
+    body:
+      encoding: UTF-8
+      string: '{"id":"a-group-trigger","name":"A Group Trigger","enabled":false,"severity":"HIGH","autoResolve":false,"autoResolveAlerts":true,"eventType":"ALERT","description":"A
+        Group Trigger generated from test","autoEnable":false,"autoDisable":false,"context":{"alert-profiles":"profile1"},"type":"GROUP","tags":{"group-tname":"group-tvalue"},"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","actions":[]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '395'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/a-group-trigger
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '483'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"a-group-trigger","name":"A
+        Group Trigger","description":"A Group Trigger generated from test","type":"GROUP","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","context":{"alert-profiles":"profile1"},"tags":{"group-tname":"group-tvalue"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":false,"firingMatch":"ALL","source":"_none_"}'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: delete
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger/dampenings/28026b36-8fe4-4332-84c8-524e173a68bf-a-group-trigger-FIRING
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '552'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","id":"member1","name":"Member
+        One","description":"A Group Trigger generated from test","type":"MEMBER","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","context":{"alert-profiles":"profile1"},"tags":{"group-tname":"group-tvalue"},"autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","dataIdMap":{"my-metric-id":"my-metric-id-member1"},"memberOf":"a-group-trigger","enabled":false,"firingMatch":"ALL","source":"_none_"}'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1/conditions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '593'
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":2,"conditionSetIndex":1,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING-2-1","dataId":"my-metric-id-member1","operator":"LT","threshold":5.0},{"tenantId":"28026b36-8fe4-4332-84c8-524e173a68bf","triggerId":"member1","triggerMode":"FIRING","type":"THRESHOLD","conditionSetSize":2,"conditionSetIndex":2,"conditionId":"28026b36-8fe4-4332-84c8-524e173a68bf-member1-FIRING-2-2","dataId":"my-metric-id2-member1","operator":"GT","threshold":50.0}]'
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/member1/dampenings
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: ASCII-8BIT
+      string: "[]"
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+- request:
+    method: delete
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/groups/a-group-trigger
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 04 May 2016 15:45:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 04 May 2016 15:45:46 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
Group triggers where not included in the preliminar mapping of the ruby client.
I have added partial support to cover the MiQ scenarios needed for the integration of MiQ Alerts and Hawkular Alerts.
So, this is not a fully 1-1 mapping between the Hawkular Alerts API in ruby, but extending the necessary API functions.
Please, @jshaughn, @pilhuhn, @Jiri-Kremser, @abonas take a look into the changes.
Thanks,
