### PR TITLE
Issue 52: adding a method for listing the operations stored in inventory

### DIFF
--- a/lib/hawkular/inventory/inventory_api.rb
+++ b/lib/hawkular/inventory/inventory_api.rb
@@ -419,6 +419,28 @@ module Hawkular::Inventory
       MetricType.new(new_mt)
     end
 
+    # List operation definitions (types) for a given resource type
+    # @param [String] resource_type_path canonical path of the resource type entity
+    # @return [Array<String>] List of operation type ids
+    def list_operation_definitions(resource_type_path)
+      parsed_path = CanonicalPath.parse(resource_type_path.to_s)
+      feed_id = parsed_path.feed_id
+      resource_type_id = parsed_path.resource_type_id
+      ret = http_get("/feeds/#{feed_id}/resourceTypes/#{resource_type_id}/operationTypes")
+      ret.map { |ot| ot['id'] }
+    end
+
+    # List operation definitions (types) for a given resource
+    # @param [String] resource_path canonical path of the resource entity
+    # @return [Array<String>] List of operation type ids
+    def list_operation_definitions_for_resource(resource_path)
+      parsed_path = CanonicalPath.parse(resource_path.to_s)
+      feed_id = parsed_path.feed_id
+      resource_type_id = parsed_path.resource_type_id
+      ret = http_get("/feeds/#{feed_id}/resourceTypes/#{resource_type_id}/operationTypes")
+      ret.map { |ot| ot['id'] }
+    end
+
     # Create a Metric and associate it with a resource.
     # @param [String] metric_type_path Canonical path of the metric type of the new metric.
     # @param [String] resource_path Canonical path of the resource to which we want to associate the metric.

--- a/lib/hawkular/inventory/inventory_api.rb
+++ b/lib/hawkular/inventory/inventory_api.rb
@@ -434,11 +434,8 @@ module Hawkular::Inventory
     # @param [String] resource_path canonical path of the resource entity
     # @return [Array<String>] List of operation type ids
     def list_operation_definitions_for_resource(resource_path)
-      parsed_path = CanonicalPath.parse(resource_path.to_s)
-      feed_id = parsed_path.feed_id
-      resource_type_id = parsed_path.resource_type_id
-      ret = http_get("/feeds/#{feed_id}/resourceTypes/#{resource_type_id}/operationTypes")
-      ret.map { |ot| ot['id'] }
+      resource = get_resource(resource_path.to_s, false)
+      list_operation_definitions(resource.type_path)
     end
 
     # Create a Metric and associate it with a resource.

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -244,16 +244,22 @@ module Hawkular::Inventory::RSpec
     end
 
     it 'Should list operation definitions of given resource type' do
-      wild_flies = @client.list_resources_for_type(feed_id, 'WildFly Server')
-      resource_type_path = wild_flies[0].type_path
+      operation_definitions = @client.list_operation_definitions(wildfly_type.to_s)
 
-      operation_types = @client.list_operation_definitions(resource_type_path)
+      expect(operation_definitions).not_to be_empty
+      expect(operation_definitions).to include('JDR')
+      expect(operation_definitions).to include('Reload')
+      expect(operation_definitions).to include('Shutdown')
+      expect(operation_definitions).to include('Deploy')
+    end
 
-      expect(operation_types).not_to be_empty
-      expect(operation_types).to include('JDR')
-      expect(operation_types).to include('Reload')
-      expect(operation_types).to include('Shutdown')
-      expect(operation_types).to include('Deploy')
+    it 'Should list operation definitions of given resource' do
+      resources = @client.list_resources_for_type(wildfly_type.to_s)
+      wild_fly = resources[0]
+      operation_definitions = @client.list_operation_definitions_for_resource(wild_fly.path.to_s)
+
+      expect(operation_definitions).not_to be_empty
+      expect(operation_definitions).to include('JDR')
     end
 
     it 'Should create a feed' do

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -243,6 +243,19 @@ module Hawkular::Inventory::RSpec
       expect(config['value']['Driver Name']).to eq('h2')
     end
 
+    it 'Should list operation definitions of given resource type' do
+      wild_flies = @client.list_resources_for_type(feed_id, 'WildFly Server')
+      resource_type_path = wild_flies[0].type_path
+
+      operation_types = @client.list_operation_definitions(resource_type_path)
+
+      expect(operation_types).not_to be_empty
+      expect(operation_types).to include('JDR')
+      expect(operation_types).to include('Reload')
+      expect(operation_types).to include('Shutdown')
+      expect(operation_types).to include('Deploy')
+    end
+
     it 'Should create a feed' do
       new_feed_id = 'feed_1123sdncisud6237ui23hjbdscuzsad'
       ret = @client.create_feed new_feed_id

--- a/spec/vcr_cassettes/Inventory/Templates/Should_list_operation_definitions_of_given_resource.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_list_operation_definitions_of_given_resource.yml
@@ -1,0 +1,185 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resourceTypes/WildFly%20Server/resources
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 12 May 2016 16:05:20 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '351'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resourceTypes/WildFly%20Server/resources>;
+        rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/rt;WildFly%20Server",
+            "name" : "WildFly Server",
+            "id" : "WildFly Server"
+          },
+          "name" : "localhost/Local",
+          "id" : "Local~~"
+        } ]
+    http_version: 
+  recorded_at: Thu, 12 May 2016 16:05:20 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resources/Local~~
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 12 May 2016 16:05:20 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '347'
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/rt;WildFly%20Server",
+            "name" : "WildFly Server",
+            "id" : "WildFly Server"
+          },
+          "name" : "localhost/Local",
+          "id" : "Local~~"
+        }
+    http_version: 
+  recorded_at: Thu, 12 May 2016 16:05:20 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resourceTypes/WildFly%20Server/operationTypes
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 12 May 2016 16:05:20 GMT
+      X-Total-Count:
+      - '4'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '667'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resourceTypes/WildFly%20Server/operationTypes>;
+        rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/rt;WildFly%20Server/ot;JDR",
+          "name" : "JDR",
+          "id" : "JDR"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/rt;WildFly%20Server/ot;Reload",
+          "name" : "Reload",
+          "id" : "Reload"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/rt;WildFly%20Server/ot;Shutdown",
+          "name" : "Shutdown",
+          "id" : "Shutdown"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/rt;WildFly%20Server/ot;Deploy",
+          "name" : "Deploy",
+          "id" : "Deploy"
+        } ]
+    http_version: 
+  recorded_at: Thu, 12 May 2016 16:05:20 GMT
+recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Inventory/Templates/Should_list_operation_definitions_of_given_resource_type.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Should_list_operation_definitions_of_given_resource_type.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resourceTypes/WildFly%20Server/resources
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 09 May 2016 15:08:25 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '351'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resourceTypes/WildFly%20Server/resources>;
+        rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/r;Local~~",
+          "type" : {
+            "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/rt;WildFly%20Server",
+            "name" : "WildFly Server",
+            "id" : "WildFly Server"
+          },
+          "name" : "localhost/Local",
+          "id" : "Local~~"
+        } ]
+    http_version: 
+  recorded_at: Mon, 09 May 2016 15:08:25 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resourceTypes/WildFly%20Server/operationTypes
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 09 May 2016 15:08:25 GMT
+      X-Total-Count:
+      - '4'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '667'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/feeds/<%= feed_uuid %>/resourceTypes/WildFly%20Server/operationTypes>;
+        rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/rt;WildFly%20Server/ot;JDR",
+          "name" : "JDR",
+          "id" : "JDR"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/rt;WildFly%20Server/ot;Reload",
+          "name" : "Reload",
+          "id" : "Reload"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/rt;WildFly%20Server/ot;Shutdown",
+          "name" : "Shutdown",
+          "id" : "Shutdown"
+        }, {
+          "path" : "/t;28026b36-8fe4-4332-84c8-524e173a68bf/f;<%= feed_uuid %>/rt;WildFly%20Server/ot;Deploy",
+          "name" : "Deploy",
+          "id" : "Deploy"
+        } ]
+    http_version: 
+  recorded_at: Mon, 09 May 2016 15:08:25 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
Only the method for retrieving all the operations declared in the inventory has been added. Inventory is storing more info under the `../resourceTypes/foo/operationTypes/bar/data` endpoint, but this endpoint is currently broken.

This fixes issue #52 
