### PR TITLE
Let the gem always provide HTTP header Hawkular-Tenant

### DIFF
--- a/lib/hawkular/base_client.rb
+++ b/lib/hawkular/base_client.rb
@@ -182,8 +182,8 @@ module Hawkular
     end
 
     def tenant_header
-      @options[:tenant].nil? ? {} : { :'Hawkular-Tenant' => @options[:tenant],
-                                      'tenantId' => @options[:tenant] }
+      @options[:tenant].nil? ? { 'Hawkular-Tenant' => 'hawkular' } : { :'Hawkular-Tenant' => @options[:tenant],
+                                                                       'tenantId'         => @options[:tenant] }
     end
 
     def handle_fault(f)


### PR DESCRIPTION
Use default value 'hawkular'. It can still be overidden by the client options.

@Jiri-Kremser please take a look, this logic may not be right but hopefully it's just simple like this.
@pilhuhn take a look and see whether you think this is in line with our decision to just send the default header value.
