### PR TITLE
Adding a way to omit the Hawkular-Tenant header.

### DIFF
--- a/lib/hawkular/base_client.rb
+++ b/lib/hawkular/base_client.rb
@@ -146,8 +146,14 @@ module Hawkular
     end
 
     def tenant_header
-      @options[:tenant].nil? ? { 'Hawkular-Tenant' => 'hawkular' } : { :'Hawkular-Tenant' => @options[:tenant],
-                                                                       'tenantId'         => @options[:tenant] }
+      if @options[:tenant].nil?
+        { 'Hawkular-Tenant' => 'hawkular' }
+      elsif @options[:tenant].empty?
+        {}
+      else
+        { :'Hawkular-Tenant' => @options[:tenant],
+          'tenantId'         => @options[:tenant] }
+      end
     end
 
     def handle_fault(f)


### PR DESCRIPTION
empty string disables it. It's better than using the nil value, because both

``` ruby
{}[:tenant].nil?
{:tenant=>nil}[:tenant].nil?
```

..return true
