### PR TITLE
Fix check of enabled flag for add_deployment operation

### DIFF
--- a/lib/hawkular/operations/operations_api.rb
+++ b/lib/hawkular/operations/operations_api.rb
@@ -134,7 +134,7 @@ module Hawkular::Operations
     #
     # @param callback [Block] callback that is run after the operation is done
     def add_deployment(hash, &callback)
-      hash[:enabled] ||= true
+      hash[:enabled] = hash.key?(:enabled) ? hash[:enabled] : true
       required = [:resource_path, :destination_file_name, :binary_content]
       check_pre_conditions hash, required, &callback
 


### PR DESCRIPTION
The enabled flag was being set with `hash[:enabled] ||= true` which, if enabled
would be defined and set to false, it would evaluate as false and set it to true.

This checks if it is defined and only if it is not, it sets the default to true.

Fixes #86 
