### PR TITLE
Add rubocop rule for curly braces in hash parameter to depend on context

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,5 @@ ModuleLength:
   Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false
+Style/BracesAroundHashParameters:
+  EnforcedStyle: context_dependent

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -79,7 +79,7 @@ describe 'Base Spec' do
   it 'should pass http_proxy_uri to rest_client' do
     proxy_uri = 'http://myproxy.com'
     c = Hawkular::BaseClient.new('not-needed-for-this-test', {},
-                                 http_proxy_uri: proxy_uri)
+                                 { http_proxy_uri: proxy_uri })
     rc = c.rest_client('myurl')
 
     expect(rc.options[:proxy]).to eq(proxy_uri)


### PR DESCRIPTION
Had this problem when trying rubocop on my changes.

https://github.com/josejulio/hawkular-client-ruby/blob/4f7a1bc1e0a9864c018bfc6f7964596ebacd4cb6/spec/integration/metric_spec.rb#L121-L123

More info:
https://github.com/ManageIQ/guides/pull/125
https://github.com/bbatsov/rubocop/issues/2063
