### PR TITLE
Fix missing firing_match and auto_resolve_match fields on Trigger

### DIFF
--- a/lib/hawkular/alerts/alerts_api.rb
+++ b/lib/hawkular/alerts/alerts_api.rb
@@ -322,7 +322,7 @@ module Hawkular::Alerts
     attr_accessor :auto_resolve, :auto_resolve_alerts, :tags, :type
     attr_accessor :tenant, :description, :group, :severity, :event_type, :event_category, :member_of, :data_id_map
     attr_reader :conditions, :dampenings
-    attr_accessor :enabled, :actions
+    attr_accessor :enabled, :actions, :firing_match, :auto_resolve_match
 
     def initialize(trigger_hash)
       return if trigger_hash.nil?
@@ -348,6 +348,8 @@ module Hawkular::Alerts
       @context = trigger_hash['context']
       @type = trigger_hash['type']
       @tags = trigger_hash['tags']
+      @firing_match = trigger_hash['firingMatch']
+      @auto_resolve_match = trigger_hash['autoResolveMatch']
       # acts = trigger_hash['actions']
       # acts.each { |a| @actions.push(Action.new(a)) } unless acts.nil?
     end
@@ -359,7 +361,8 @@ module Hawkular::Alerts
         ret[0, 1].downcase + ret[1..-1]
       end
       fields = [:id, :name, :enabled, :severity, :auto_resolve, :auto_resolve_alerts, :event_type, :event_category,
-                :description, :auto_enable, :auto_disable, :context, :type, :tags, :member_of, :data_id_map]
+                :description, :auto_enable, :auto_disable, :context, :type, :tags, :member_of, :data_id_map,
+                :firing_match, :auto_resolve_match]
 
       fields.each do |field|
         camelized_field = to_camel.call(field)

--- a/spec/vcr_cassettes/Alert/Triggers/Should_create_a_firing_ALL_ANY_trigger.yml
+++ b/spec/vcr_cassettes/Alert/Triggers/Should_create_a_firing_ALL_ANY_trigger.yml
@@ -1,0 +1,463 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/trigger
+    body:
+      encoding: UTF-8
+      string: '{"trigger":{"id":"my-cool-trigger","name":"Just a trigger","enabled":true,"severity":"HIGH","description":"Just
+        a test trigger","actions":[]},"conditions":[],"dampenings":[]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '174'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 01 Jul 2016 13:07:20 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '374'
+    body:
+      encoding: UTF-8
+      string: '{"trigger":{"tenantId":"hawkular","id":"my-cool-trigger","name":"Just
+        a trigger","description":"Just a test trigger","type":"STANDARD","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ALL","source":"_none_"}}'
+    http_version: 
+  recorded_at: Fri, 01 Jul 2016 13:07:20 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/my-cool-trigger
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 01 Jul 2016 13:07:20 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '362'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"my-cool-trigger","name":"Just a trigger","description":"Just
+        a test trigger","type":"STANDARD","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ALL","enabled":true,"firingMatch":"ALL","source":"_none_"}'
+    http_version: 
+  recorded_at: Fri, 01 Jul 2016 13:07:20 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/my-cool-trigger/conditions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 01 Jul 2016 13:07:20 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Fri, 01 Jul 2016 13:07:20 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/my-cool-trigger/dampenings
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 01 Jul 2016 13:07:20 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Fri, 01 Jul 2016 13:07:20 GMT
+- request:
+    method: delete
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/my-cool-trigger
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 01 Jul 2016 13:07:20 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 01 Jul 2016 13:07:20 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/trigger
+    body:
+      encoding: UTF-8
+      string: '{"trigger":{"id":"my-cool-trigger","name":"Just a trigger","enabled":true,"severity":"HIGH","description":"Just
+        a test trigger","firingMatch":"ANY","autoResolveMatch":"ANY","actions":[]},"conditions":[],"dampenings":[]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '219'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 01 Jul 2016 13:07:20 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '374'
+    body:
+      encoding: UTF-8
+      string: '{"trigger":{"tenantId":"hawkular","id":"my-cool-trigger","name":"Just
+        a trigger","description":"Just a test trigger","type":"STANDARD","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ANY","enabled":true,"firingMatch":"ANY","source":"_none_"}}'
+    http_version: 
+  recorded_at: Fri, 01 Jul 2016 13:07:20 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/my-cool-trigger
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 01 Jul 2016 13:07:20 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '362'
+    body:
+      encoding: UTF-8
+      string: '{"tenantId":"hawkular","id":"my-cool-trigger","name":"Just a trigger","description":"Just
+        a test trigger","type":"STANDARD","eventType":"ALERT","eventCategory":null,"eventText":null,"severity":"HIGH","autoDisable":false,"autoEnable":false,"autoResolve":false,"autoResolveAlerts":true,"autoResolveMatch":"ANY","enabled":true,"firingMatch":"ANY","source":"_none_"}'
+    http_version: 
+  recorded_at: Fri, 01 Jul 2016 13:07:20 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/my-cool-trigger/conditions
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 01 Jul 2016 13:07:20 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Fri, 01 Jul 2016 13:07:20 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/my-cool-trigger/dampenings
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 01 Jul 2016 13:07:20 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Fri, 01 Jul 2016 13:07:20 GMT
+- request:
+    method: delete
+    uri: http://jdoe:password@localhost:8080/hawkular/alerts/triggers/my-cool-trigger
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 01 Jul 2016 13:07:20 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 01 Jul 2016 13:07:20 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
This PR fixes a couple of fields needed on Trigger to define the type of matching.
This fix is needed for ManageIQ Middleware alerting work, so once merged a new version will be needed on MiQ to continue the alerting work.
