### PR TITLE
Fix rack version at 1.6.4 to support ruby <v2.2.2

### DIFF
--- a/hawkularclient.gemspec
+++ b/hawkularclient.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('vcr')
   gem.add_development_dependency('rubocop', '= 0.34.2')
   gem.add_development_dependency('coveralls')
+  gem.add_development_dependency('rack', '= 1.6.4')
 
   gem.rdoc_options << '--title' << gem.name <<
     '--main' << 'README.rdoc' << '--line-numbers' << '--inline-source'


### PR DESCRIPTION
Rack 2.0.1 has been released which requires Ruby >= 2.2.2

Let's continue using 1.6.4 so that also older Rubies can be supported.
