### PR TITLE
Use the pessimistic operator as suggested in #99 for the rack version

### DIFF
--- a/hawkularclient.gemspec
+++ b/hawkularclient.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('vcr')
   gem.add_development_dependency('rubocop', '= 0.34.2')
   gem.add_development_dependency('coveralls')
-  gem.add_development_dependency('rack', '= 1.6.4')
+  gem.add_development_dependency('rack', '~> 1.6.4')
 
   gem.rdoc_options << '--title' << gem.name <<
     '--main' << 'README.rdoc' << '--line-numbers' << '--inline-source'


### PR DESCRIPTION
Use the pessimistic operator as suggested in #99 for the rack version.
The problematic bump was at 2.x, so minors / z-streams for 1.x should be ok.

@abonas 
