### PR TITLE
Make metrics aware of HWKMETRICS-24

### DIFF
--- a/spec/integration/alerts_spec.rb
+++ b/spec/integration/alerts_spec.rb
@@ -598,8 +598,12 @@ module Hawkular::Alerts::RSpec
         expect(trigger.dampenings.size).to be(0)
 
         # Trigger is set up - send a metric value to trigger it.
-        metric_client = Hawkular::Metrics::Client.new('http://localhost:8080/hawkular/metrics',
-                                                      creds, options)
+        metric_client = nil
+        ::RSpec::Mocks.with_temporary_scope do
+          mock_metrics_version
+          metric_client = Hawkular::Metrics::Client.new('http://localhost:8080/hawkular/metrics',
+                                                        creds, options)
+        end
 
         data_point = { timestamp: Time.now.to_i * 1000, value: 42 }
         data = [{ id: 'my-metric-id1', data: [data_point] }]

--- a/spec/integration/hawkular_client_spec.rb
+++ b/spec/integration/hawkular_client_spec.rb
@@ -14,6 +14,7 @@ module Hawkular::Client::RSpec
       }
       ::RSpec::Mocks.with_temporary_scope do
         mock_inventory_client '0.17.2.Final'
+        mock_metrics_version
         @hawkular_client = Hawkular::Client.new(entrypoint: HOST, credentials: @creds, options: { tenant: 'hawkular' })
       end
       @state = {
@@ -50,25 +51,31 @@ module Hawkular::Client::RSpec
       it 'Should work with URI' do
         uri = URI.parse HOST
         opts = { tenant: 'hawkular' }
-
-        the_client = Hawkular::Client.new(entrypoint: uri, credentials: @creds, options: opts)
-        expect { the_client.inventory.list_feeds }.to_not raise_error
+        ::RSpec::Mocks.with_temporary_scope do
+          mock_metrics_version
+          the_client = Hawkular::Client.new(entrypoint: uri, credentials: @creds, options: opts)
+          expect { the_client.inventory.list_feeds }.to_not raise_error
+        end
       end
 
       it 'Should work with URI on metrics client' do
         uri = URI.parse HOST
         opts = { tenant: 'hawkular' }
-
-        the_client = Hawkular::Metrics::Client.new(uri, @creds, opts)
-        expect { the_client.http_get '/status' }.to_not raise_error
+        ::RSpec::Mocks.with_temporary_scope do
+          mock_metrics_version
+          the_client = Hawkular::Metrics::Client.new(uri, @creds, opts)
+          expect { the_client.http_get '/status' }.to_not raise_error
+        end
       end
 
       it 'Should work with https URI on metrics client' do
         uri = URI.parse 'https://localhost:8080'
         opts = { tenant: 'hawkular' }
-
-        the_client = Hawkular::Metrics::Client.new(uri, @creds, opts)
-        expect !the_client.nil?
+        ::RSpec::Mocks.with_temporary_scope do
+          mock_metrics_version
+          the_client = Hawkular::Metrics::Client.new(uri, @creds, opts)
+          expect !the_client.nil?
+        end
       end
     end
 
@@ -144,7 +151,10 @@ module Hawkular::Client::RSpec
       include Hawkular::Metrics::RSpec
 
       before(:all) do
-        @client = Hawkular::Metrics::Client.new(HOST, @creds)
+        ::RSpec::Mocks.with_temporary_scope do
+          mock_metrics_version
+          @client = Hawkular::Metrics::Client.new(HOST, @creds)
+        end
       end
 
       it 'Should both work the same way when pushing metric data to non-existing counter' do
@@ -274,8 +284,11 @@ module Hawkular::Client::RSpec
         uri = URI.parse HOST
         opts = { tenant: 'hawkular' }
         WebSocketVCR.record(example, self) do
-          the_client = Hawkular::Client.new(entrypoint: uri, credentials: @creds, options: opts)
-          expect { the_client.operations }.to_not raise_error
+          ::RSpec::Mocks.with_temporary_scope do
+            mock_metrics_version
+            the_client = Hawkular::Client.new(entrypoint: uri, credentials: @creds, options: opts)
+            expect { the_client.operations }.to_not raise_error
+          end
         end
       end
 

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -4,28 +4,40 @@ describe Hawkular::Metrics::Client do
   context 'client initialization' do
     it 'should accept no option' do
       credentials = { username: 'mockuser', password: 'mockpass' }
-      Hawkular::Metrics::Client.new(HOST, credentials)
+      ::RSpec::Mocks.with_temporary_scope do
+        mock_metrics_version
+        Hawkular::Metrics::Client.new(HOST, credentials)
+      end
     end
 
     it 'should accept Hawkular-Tenant option' do
       credentials = { username: 'mockuser', password: 'mockpass' }
-      @client = Hawkular::Metrics::Client.new(HOST, credentials, tenant: 'foo')
-      headers = @client.send(:http_headers)
-      expect(headers[:'Hawkular-Tenant']).to eql('foo')
+      ::RSpec::Mocks.with_temporary_scope do
+        mock_metrics_version
+        @client = Hawkular::Metrics::Client.new(HOST, credentials, tenant: 'foo')
+        headers = @client.send(:http_headers)
+        expect(headers[:'Hawkular-Tenant']).to eql('foo')
+      end
     end
 
     it 'should define subcomponents' do
-      client = Hawkular::Metrics::Client.new HOST
-      expect(client.tenants).not_to be nil
-      expect(client.counters).not_to be nil
-      expect(client.gauges).not_to be nil
+      ::RSpec::Mocks.with_temporary_scope do
+        mock_metrics_version
+        client = Hawkular::Metrics::Client.new HOST
+        expect(client.tenants).not_to be nil
+        expect(client.counters).not_to be nil
+        expect(client.gauges).not_to be nil
+      end
     end
   end
 
   context 'http comms' do
     before(:each) do
       credentials = { username: 'mockuser', password: 'mockpass' }
-      @client = Hawkular::Metrics::Client.new(HOST, credentials)
+      ::RSpec::Mocks.with_temporary_scope do
+        mock_metrics_version
+        @client = Hawkular::Metrics::Client.new(HOST, credentials)
+      end
     end
 
     it 'should add Accept: headers' do

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Availability_metrics/Should_create_Availability_definition_using_MetricDefinition_parameter.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Availability_metrics/Should_create_Availability_definition_using_MetricDefinition_parameter.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","dataRetention":90,"tags":{"tag":"value"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '87'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/metrics/availability/<%= id %>
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/<%= id %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '142'
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","tags":{"tag":"value"},"dataRetention":90,"type":"availability","tenantId":"vcr-test-tenant-123"}'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Availability_metrics/Should_create_and_return_Availability_using_Hash_parameter.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Availability_metrics/Should_create_and_return_Availability_using_Hash_parameter.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","dataRetention":123,"tags":{"some":"value"},"tenantId":"vcr-test-tenant-123"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '122'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/metrics/availability/<%= id %>
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/<%= id %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '144'
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","tags":{"some":"value"},"dataRetention":123,"type":"availability","tenantId":"vcr-test-tenant-123"}'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Availability_metrics/Should_group_contiguous_values.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Availability_metrics/Should_group_contiguous_values.yml
@@ -1,0 +1,93 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/<%= id %>/raw
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":<%= minus50 %>,"value":"up"},{"timestamp":<%= minus40 %>,"value":"up"},{"timestamp":<%= minus30 %>,"value":"down"},{"timestamp":<%= minus20 %>,"value":"down"},{"timestamp":<%= minus10 %>,"value":"down"},{"timestamp":<%= now %>,"value":"up"}]'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '253'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/<%= id %>/raw/?distinct=true&order=ASC
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '126'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":<%= minus50 %>,"value":"up"},{"timestamp":<%= minus30 %>,"value":"down"},{"timestamp":<%= now %>,"value":"up"}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Availability_metrics/Should_push_metric_data_to_non-existing_Availability.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Availability_metrics/Should_push_metric_data_to_non-existing_Availability.yml
@@ -1,0 +1,138 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/<%= id %>/raw
+    body:
+      encoding: UTF-8
+      string: '[{"value":"UP","timestamp":1469453591393}]'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '42'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '42'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1469453591393,"value":"up"}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/<%= id %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '176'
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","dataRetention":7,"type":"availability","tenantId":"vcr-test-tenant-123","minTimestamp":1469453591393,"maxTimestamp":1469453591393}'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Availability_metrics/Should_update_tags_for_Availability_definition.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Availability_metrics/Should_update_tags_for_Availability_definition.yml
@@ -1,0 +1,230 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","tags":{"myTag":"<%= id %>"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '101'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/metrics/availability/<%= id %>
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/<%= id %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '174'
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","tags":{"myTag":"<%= id %>"},"dataRetention":7,"type":"availability","tenantId":"vcr-test-tenant-123"}'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: put
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/<%= id %>/tags
+    body:
+      encoding: UTF-8
+      string: '{"newTag":"newValue"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '21'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/<%= id %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '194'
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","tags":{"myTag":"<%= id %>","newTag":"newValue"},"dataRetention":7,"type":"availability","tenantId":"vcr-test-tenant-123"}'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/metrics/?tags=myTag:<%= id %>&type=availability
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '196'
+    body:
+      encoding: UTF-8
+      string: '[{"id":"<%= id %>","tags":{"myTag":"<%= id %>","newTag":"newValue"},"dataRetention":7,"type":"availability","tenantId":"vcr-test-tenant-123"}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Counter_metrics/Should_create_and_return_counter_using_Hash_parameter.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Counter_metrics/Should_create_and_return_counter_using_Hash_parameter.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","dataRetention":123,"tags":{"some":"value"},"tenantId":"vcr-test-tenant-123"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '122'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/metrics/counters/<%= id %>
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '139'
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","tags":{"some":"value"},"dataRetention":123,"type":"counter","tenantId":"vcr-test-tenant-123"}'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Counter_metrics/Should_create_counter_definition_using_MetricDefinition_parameter.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Counter_metrics/Should_create_counter_definition_using_MetricDefinition_parameter.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","dataRetention":90,"tags":{"tag":"value"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '87'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/metrics/counters/<%= id %>
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","tags":{"tag":"value"},"dataRetention":90,"type":"counter","tenantId":"vcr-test-tenant-123"}'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Counter_metrics/Should_get_metrics_as_bucketed_results.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Counter_metrics/Should_get_metrics_as_bucketed_results.yml
@@ -1,0 +1,230 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '45'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/metrics/counters/<%= id %>
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw
+    body:
+      encoding: UTF-8
+      string: '[{"value":110,"timestamp":<%= minus110 %>},{"value":100,"timestamp":<%= minus100 %>},{"value":90,"timestamp":<%= minus90 %>},{"value":80,"timestamp":<%= minus80 %>},{"value":70,"timestamp":<%= minus70 %>},{"value":60,"timestamp":<%= minus60 %>},{"value":50,"timestamp":<%= minus50 %>},{"value":40,"timestamp":<%= minus40 %>},{"value":30,"timestamp":<%= minus30 %>},{"value":20,"timestamp":<%= minus20 %>},{"value":10,"timestamp":<%= minus10 %>}]'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '432'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/stats/?buckets=5&end=<%= minus5 %>&start=<%= minus105 %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '645'
+    body:
+      encoding: UTF-8
+      string: '[{"start":<%= minus105 %>,"end":1469453591084,"min":90.0,"avg":95.0,"median":90.0,"max":100.0,"sum":190.0,"samples":2,"empty":false},{"start":1469453591084,"end":1469453591104,"min":70.0,"avg":75.0,"median":70.0,"max":80.0,"sum":150.0,"samples":2,"empty":false},{"start":1469453591104,"end":1469453591124,"min":50.0,"avg":55.0,"median":50.0,"max":60.0,"sum":110.0,"samples":2,"empty":false},{"start":1469453591124,"end":1469453591144,"min":30.0,"avg":35.0,"median":30.0,"max":40.0,"sum":70.0,"samples":2,"empty":false},{"start":1469453591144,"end":1469453591164,"min":10.0,"avg":15.0,"median":10.0,"max":20.0,"sum":30.0,"samples":2,"empty":false}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/stats/?buckets=2&end=<%= minus5 %>&start=<%= minus105 %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '260'
+    body:
+      encoding: UTF-8
+      string: '[{"start":<%= minus105 %>,"end":1469453591114,"min":60.0,"avg":80.0,"median":80.0,"max":100.0,"sum":400.0,"samples":5,"empty":false},{"start":1469453591114,"end":1469453591164,"min":10.0,"avg":30.0,"median":30.0,"max":50.0,"sum":150.0,"samples":5,"empty":false}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/stats/?bucketDuration=50ms&end=<%= minus5 %>&start=<%= minus105 %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '260'
+    body:
+      encoding: UTF-8
+      string: '[{"start":<%= minus105 %>,"end":1469453591114,"min":60.0,"avg":80.0,"median":80.0,"max":100.0,"sum":400.0,"samples":5,"empty":false},{"start":1469453591114,"end":1469453591164,"min":10.0,"avg":30.0,"median":30.0,"max":50.0,"sum":150.0,"samples":5,"empty":false}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Counter_metrics/Should_get_metrics_with_limit_and_order.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Counter_metrics/Should_get_metrics_with_limit_and_order.yml
@@ -1,0 +1,314 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '45'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/metrics/counters/<%= id %>
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw
+    body:
+      encoding: UTF-8
+      string: '[{"value":1,"timestamp":<%= minus30 %>},{"value":2,"timestamp":<%= minus20 %>},{"value":3,"timestamp":<%= minus10 %>}]'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '115'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '115'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":<%= minus10 %>,"value":3},{"timestamp":<%= minus20 %>,"value":2},{"timestamp":<%= minus30 %>,"value":1}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw
+    body:
+      encoding: UTF-8
+      string: '[{"value":4,"timestamp":1469453591082}]'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '153'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1469453591082,"value":4},{"timestamp":<%= minus10 %>,"value":3},{"timestamp":<%= minus20 %>,"value":2},{"timestamp":<%= minus30 %>,"value":1}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw/?limit=1&order=DESC
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1469453591082,"value":4}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw/?end=<%= minus4h %>&start=<%= minus8h %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Counter_metrics/Should_push_metric_data_to_existing_counter.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Counter_metrics/Should_push_metric_data_to_existing_counter.yml
@@ -1,0 +1,269 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '45'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/metrics/counters/<%= id %>
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw
+    body:
+      encoding: UTF-8
+      string: '[{"value":1,"timestamp":<%= minus30 %>},{"value":2,"timestamp":<%= minus20 %>},{"value":3,"timestamp":<%= minus10 %>}]'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '115'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '115'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":<%= minus10 %>,"value":3},{"timestamp":<%= minus20 %>,"value":2},{"timestamp":<%= minus30 %>,"value":1}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw
+    body:
+      encoding: UTF-8
+      string: '[{"value":4,"timestamp":1469453590956}]'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '153'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1469453590956,"value":4},{"timestamp":<%= minus10 %>,"value":3},{"timestamp":<%= minus20 %>,"value":2},{"timestamp":<%= minus30 %>,"value":1}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw/?end=<%= minus4h %>&start=<%= minus8h %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Counter_metrics/Should_push_metric_data_to_non-existing_counter.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Counter_metrics/Should_push_metric_data_to_non-existing_counter.yml
@@ -1,0 +1,138 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw
+    body:
+      encoding: UTF-8
+      string: '[{"value":4,"timestamp":1469453591257}]'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1469453591257,"value":4}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '171'
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","dataRetention":7,"type":"counter","tenantId":"vcr-test-tenant-123","minTimestamp":1469453591257,"maxTimestamp":1469453591257}'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Gauge_metrics/Should_create_gauge_definition_using_Hash.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Gauge_metrics/Should_create_gauge_definition_using_Hash.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","dataRetention":123,"tags":{"some":"value"},"tenantId":"vcr-test-tenant-123"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '122'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/metrics/gauges/<%= id %>
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '137'
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","tags":{"some":"value"},"dataRetention":123,"type":"gauge","tenantId":"vcr-test-tenant-123"}'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Gauge_metrics/Should_create_gauge_definition_using_MetricDefinition.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Gauge_metrics/Should_create_gauge_definition_using_MetricDefinition.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","dataRetention":90,"tags":{"tag":"value"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '87'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/metrics/gauges/<%= id %>
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '135'
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","tags":{"tag":"value"},"dataRetention":90,"type":"gauge","tenantId":"vcr-test-tenant-123"}'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Gauge_metrics/Should_push_metric_data_to_existing_gauge.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Gauge_metrics/Should_push_metric_data_to_existing_gauge.yml
@@ -1,0 +1,269 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '45'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/metrics/gauges/<%= id %>
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>/raw
+    body:
+      encoding: UTF-8
+      string: '[{"value":1,"timestamp":<%= now30 %>},{"value":2,"timestamp":<%= now20 %>},{"value":3,"timestamp":<%= now10 %>}]'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '115'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '121'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":<%= now10 %>,"value":3.0},{"timestamp":<%= now20 %>,"value":2.0},{"timestamp":<%= now30 %>,"value":1.0}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>/raw
+    body:
+      encoding: UTF-8
+      string: '[{"value":4,"timestamp":1469453591902}]'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '161'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1469453591902,"value":4.0},{"timestamp":<%= now10 %>,"value":3.0},{"timestamp":<%= now20 %>,"value":2.0},{"timestamp":<%= now30 %>,"value":1.0}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw/?end=<%= ends %>&start=<%= starts %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Gauge_metrics/Should_push_metric_data_to_non-existing_gauge.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Gauge_metrics/Should_push_metric_data_to_non-existing_gauge.yml
@@ -1,0 +1,138 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>/raw
+    body:
+      encoding: UTF-8
+      string: '[{"value":3.1415926,"timestamp":1469453591773}]'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '47'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '47'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1469453591773,"value":3.1415926}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:11 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '169'
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","dataRetention":7,"type":"gauge","tenantId":"vcr-test-tenant-123","minTimestamp":1469453591773,"maxTimestamp":1469453591773}'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:11 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Gauge_metrics/Should_return_periods.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Gauge_metrics/Should_return_periods.yml
@@ -1,0 +1,93 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>/raw
+    body:
+      encoding: UTF-8
+      string: '[{"value":1,"timestamp":<%= minus30 %>},{"value":2,"timestamp":<%= minus20 %>},{"value":3,"timestamp":<%= start %>}]'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '115'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:12 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:12 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>/periods?op=lte&start=<%= before4h %>&threshold=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:12 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '31'
+    body:
+      encoding: UTF-8
+      string: "[[<%= minus30 %>,<%= start %>]]"
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:12 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Gauge_metrics/Should_update_tags_for_gauge_definition.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Gauge_metrics/Should_update_tags_for_gauge_definition.yml
@@ -1,0 +1,230 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","tags":{"myTag":"<%= id %>"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '101'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/metrics/gauges/<%= id %>
+      Date:
+      - Mon, 25 Jul 2016 13:33:12 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:12 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:12 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '167'
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","tags":{"myTag":"<%= id %>"},"dataRetention":7,"type":"gauge","tenantId":"vcr-test-tenant-123"}'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:12 GMT
+- request:
+    method: put
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>/tags
+    body:
+      encoding: UTF-8
+      string: '{"newTag":"newValue"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '21'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:12 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:12 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:12 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '187'
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>","tags":{"myTag":"<%= id %>","newTag":"newValue"},"dataRetention":7,"type":"gauge","tenantId":"vcr-test-tenant-123"}'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:12 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/metrics/?tags=myTag:<%= id %>&type=gauge
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:12 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '189'
+    body:
+      encoding: UTF-8
+      string: '[{"id":"<%= id %>","tags":{"myTag":"<%= id %>","newTag":"newValue"},"dataRetention":7,"type":"gauge","tenantId":"vcr-test-tenant-123"}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:12 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Mixed_metrics/Should_requests_raw_data_for_multiple_metrics.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Mixed_metrics/Should_requests_raw_data_for_multiple_metrics.yml
@@ -1,0 +1,330 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"ids":["<%= id1 %>","<%= id2 %>","<%= id3 %>"],"start":null,"end":null,"limit":null,"order":null}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '176'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"ids":["<%= id1 %>","<%= id2 %>","<%= id3 %>"],"start":null,"end":null,"limit":null,"order":null}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '176'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"ids":["<%= id1 %>","<%= id2 %>","<%= id3 %>"],"start":null,"end":null,"limit":null,"order":null}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '176'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2'
+    body:
+      encoding: UTF-8
+      string: "[]"
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/metrics/raw
+    body:
+      encoding: UTF-8
+      string: '{"gauges":[{"id":"<%= id1 %>","data":[{"value":1.1,"timestamp":1469453590504}]},{"id":"<%= id2 %>","data":[{"value":2.2,"timestamp":1469453590504}]},{"id":"<%= id3 %>","data":[{"value":3.3,"timestamp":1469453590504}]}],"counters":[{"id":"<%= id1 %>","data":[{"value":1,"timestamp":1469453590504}]},{"id":"<%= id2 %>","data":[{"value":2,"timestamp":1469453590504}]},{"id":"<%= id3 %>","data":[{"value":3,"timestamp":1469453590504}]}],"availabilities":[{"id":"<%= id1 %>","data":[{"value":"up","timestamp":1469453590504}]},{"id":"<%= id2 %>","data":[{"value":"down","timestamp":1469453590504}]},{"id":"<%= id3 %>","data":[{"value":"up","timestamp":1469453590504}]}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '898'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"ids":["<%= id1 %>","<%= id2 %>","<%= id3 %>"],"start":null,"end":null,"limit":null,"order":null}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '176'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '280'
+    body:
+      encoding: UTF-8
+      string: '[{"id":"<%= id1 %>","data":[{"timestamp":1469453590504,"value":1}]},{"id":"<%= id2 %>","data":[{"timestamp":1469453590504,"value":2}]},{"id":"<%= id3 %>","data":[{"timestamp":1469453590504,"value":3}]}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"ids":["<%= id1 %>","<%= id2 %>","<%= id3 %>"],"start":null,"end":null,"limit":null,"order":null}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '176'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '286'
+    body:
+      encoding: UTF-8
+      string: '[{"id":"<%= id1 %>","data":[{"timestamp":1469453590504,"value":1.1}]},{"id":"<%= id2 %>","data":[{"timestamp":1469453590504,"value":2.2}]},{"id":"<%= id3 %>","data":[{"timestamp":1469453590504,"value":3.3}]}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/raw/query
+    body:
+      encoding: UTF-8
+      string: '{"ids":["<%= id1 %>","<%= id2 %>","<%= id3 %>"],"start":null,"end":null,"limit":null,"order":null}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '176'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '291'
+    body:
+      encoding: UTF-8
+      string: '[{"id":"<%= id1 %>","data":[{"timestamp":1469453590504,"value":"up"}]},{"id":"<%= id2 %>","data":[{"timestamp":1469453590504,"value":"down"}]},{"id":"<%= id3 %>","data":[{"timestamp":1469453590504,"value":"up"}]}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Mixed_metrics/Should_send_mixed_metric_request.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Mixed_metrics/Should_send_mixed_metric_request.yml
@@ -1,0 +1,300 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/metrics/raw
+    body:
+      encoding: UTF-8
+      string: '{"gauges":[{"id":"<%= id %>","data":[{"value":1.1,"timestamp":1469453590744}]}],"counters":[{"id":"<%= id %>","data":[{"value":1,"timestamp":1469453590744}]}],"availabilities":[{"id":"<%= id %>","data":[{"value":"down","timestamp":1469453590744}]}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '330'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1469453590744,"value":1}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '41'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1469453590744,"value":1.1}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '44'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1469453590744,"value":"down"}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Mixed_metrics/Should_send_mixed_metric_request_of_a_single_type.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Mixed_metrics/Should_send_mixed_metric_request_of_a_single_type.yml
@@ -1,0 +1,273 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/metrics/raw
+    body:
+      encoding: UTF-8
+      string: '{"gauges":[],"counters":[{"id":"<%= id %>","data":[{"value":1,"timestamp":1469453590601}]}],"availabilities":[]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '139'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1469453590601,"value":1}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/metrics/raw
+    body:
+      encoding: UTF-8
+      string: '{"gauges":[],"counters":[],"availabilities":[{"id":"<%= id %>","data":[{"value":"down","timestamp":1469453590630}]}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '144'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '44'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1469453590630,"value":"down"}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/metrics/raw
+    body:
+      encoding: UTF-8
+      string: '{"gauges":[{"id":"<%= id %>","data":[{"value":1.1,"timestamp":1469453590660}]}],"counters":[],"availabilities":[]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '141'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - vcr-test-tenant-123
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '41'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1469453590660,"value":1.1}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/No_Tenant/Should_fail.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/No_Tenant/Should_fail.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/6c934cbf-7fe4-42a1-b79d-4b32c6c43971/data
+    body:
+      encoding: UTF-8
+      string: '[{"value":4,"timestamp":1469453590417}]'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '69'
+    body:
+      encoding: UTF-8
+      string: '{"errorMsg":"Tenant is not specified. Use ''Hawkular-Tenant'' header."}'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Simple/Should_be_Cool.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Simple/Should_be_Cool.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/metrics
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - localhost:8080
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Www-Authenticate:
+      - Basic realm="ApplicationRealm"
+      Content-Type:
+      - text/html;charset=UTF-8
+      Content-Length:
+      - '71'
+    body:
+      encoding: UTF-8
+      string: "<html><head><title>Error</title></head><body>Unauthorized</body></html>"
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Status/Should_return_the_version.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Status/Should_return_the_version.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '133'
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+    body:
+      encoding: UTF-8
+      string: '{"MetricsService":"STARTED","Implementation-Version":"0.17.0.Final","Built-From-Git-SHA1":"c439d3797397425d340eac7c549e330d51fc2cac"}'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Tenants/Should_create_and_return_tenant.yml
+++ b/spec/vcr_cassettes/Metrics/metrics_0_16_0/Templates/Tenants/Should_create_and_return_tenant.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/tenants
+    body:
+      encoding: UTF-8
+      string: '{"id":"c2be906a-45e8-4e2a-8aa7-25a72445ca76"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '45'
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/metrics/tenants
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/tenants
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 25 Jul 2016 13:33:10 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '388'
+    body:
+      encoding: UTF-8
+      string: '[{"id":"ec12e227-d503-45d5-bc9b-520ab35f9c65"},{"id":"dd36b5d0-4196-4c6d-9fb2-4bdd02cc6d9d"},{"id":"feda9a5b-bccd-41d5-be61-05e27a076892"},{"id":"c2be906a-45e8-4e2a-8aa7-25a72445ca76"},{"id":"7d1589ae-b50b-4c42-a8fb-b9eabe28955b"},{"id":"8863a572-bb18-4ade-b6d3-d13a87d14fba"},{"id":"dfb22c83-e35b-4e45-b96d-198384028483"},{"id":"vcr-test"},{"id":"hawkular"},{"id":"vcr-test-tenant-123"}]'
+    http_version: 
+  recorded_at: Mon, 25 Jul 2016 13:33:10 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/New_API_Counter_metrics/Should_get_metrics_as_bucketed_results.yml
+++ b/spec/vcr_cassettes/New_API_Counter_metrics/Should_get_metrics_as_bucketed_results.yml
@@ -1,0 +1,230 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters
+    body:
+      encoding: UTF-8
+      string: '{"id":"<%= id %>"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '45'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/metrics/counters/<%= id %>
+      Date:
+      - Mon, 04 Jul 2016 20:16:13 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 Jul 2016 20:16:13 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw
+    body:
+      encoding: UTF-8
+      string: '[{"value":110,"timestamp":<%= now - 110 %>},{"value":100,"timestamp":<%= now - 100 %>},{"value":90,"timestamp":<%= now - 90 %>},{"value":80,"timestamp":<%= now - 80 %>},{"value":70,"timestamp":<%= now - 70 %>},{"value":60,"timestamp":<%= now - 60 %>},{"value":50,"timestamp":<%= now - 50 %>},{"value":40,"timestamp":<%= now - 40 %>},{"value":30,"timestamp":<%= now - 30 %>},{"value":20,"timestamp":<%= now - 20 %>},{"value":10,"timestamp":<%= now - 10 %>}]'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '432'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 04 Jul 2016 20:16:13 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 Jul 2016 20:16:13 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/stats/?buckets=5&end=<%= now - 5 %>&start=<%= now - 105 %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 04 Jul 2016 20:16:13 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '645'
+    body:
+      encoding: UTF-8
+      string: '[{"start":<%= now - 105 %>,"end":<%= now - 85 %>,"min":90.0,"avg":95.0,"median":90.0,"max":100.0,"samples":2,"empty":false},{"start":<%= now - 85 %>,"end":<%= now - 65 %>,"min":70.0,"avg":75.0,"median":70.0,"max":80.0,"samples":2,"empty":false},{"start":<%= now - 65 %>,"end":<%= now - 45 %>,"min":50.0,"avg":55.0,"median":50.0,"max":60.0,"samples":2,"empty":false},{"start":<%= now - 45 %>,"end":<%= now - 25 %>,"min":30.0,"avg":35.0,"median":30.0,"max":40.0,"samples":2,"empty":false},{"start":<%= now - 25 %>,"end":<%= now - 5 %>,"min":10.0,"avg":15.0,"median":10.0,"max":20.0,"samples":2,"empty":false}]'
+    http_version: 
+  recorded_at: Mon, 04 Jul 2016 20:16:13 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/stats/?buckets=2&end=<%= now - 5 %>&start=<%= now - 105 %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 04 Jul 2016 20:16:13 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '260'
+    body:
+      encoding: UTF-8
+      string: '[{"start":<%= now - 105 %>,"end":<%= now - 55 %>,"min":60.0,"avg":80.0,"median":80.0,"max":100.0,"samples":5,"empty":false},{"start":<%= now - 55 %>,"end":<%= now - 5 %>,"min":10.0,"avg":30.0,"median":30.0,"max":50.0,"samples":5,"empty":false}]'
+    http_version: 
+  recorded_at: Mon, 04 Jul 2016 20:16:13 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/stats/?bucketDuration=50ms&end=<%= now - 5 %>&start=<%= now - 105 %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 04 Jul 2016 20:16:13 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '260'
+    body:
+      encoding: UTF-8
+      string: '[{"start":<%= now - 105 %>,"end":<%= now - 55 %>,"min":60.0,"avg":80.0,"median":80.0,"max":100.0,"samples":5,"empty":false},{"start":<%= now - 55 %>,"end":<%= now - 5 %>,"min":10.0,"avg":30.0,"median":30.0,"max":50.0,"samples":5,"empty":false}]'
+    http_version: 
+  recorded_at: Mon, 04 Jul 2016 20:16:13 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/New_API_Mixed_metrics/Should_send_mixed_metric_request.yml
+++ b/spec/vcr_cassettes/New_API_Mixed_metrics/Should_send_mixed_metric_request.yml
@@ -1,0 +1,300 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 04 Jul 2016 20:16:12 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 Jul 2016 20:16:12 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 04 Jul 2016 20:16:12 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 Jul 2016 20:16:12 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 04 Jul 2016 20:16:12 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 Jul 2016 20:16:12 GMT
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/metrics/raw
+    body:
+      encoding: UTF-8
+      string: '{"gauges":[{"id":"<%= id %>","data":[{"value":1.1,"timestamp":1467663372935}]}],"counters":[{"id":"<%= id %>","data":[{"value":1,"timestamp":1467663372935}]}],"availabilities":[{"id":"<%= id %>","data":[{"value":"down","timestamp":1467663372935}]}]}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '330'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 04 Jul 2016 20:16:12 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 04 Jul 2016 20:16:12 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 04 Jul 2016 20:16:12 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '39'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1467663372935,"value":1}]'
+    http_version: 
+  recorded_at: Mon, 04 Jul 2016 20:16:12 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 04 Jul 2016 20:16:12 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '41'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1467663372935,"value":1.1}]'
+    http_version: 
+  recorded_at: Mon, 04 Jul 2016 20:16:12 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/<%= id %>/raw/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 04 Jul 2016 20:16:12 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '44'
+    body:
+      encoding: UTF-8
+      string: '[{"timestamp":1467663372935,"value":"down"}]'
+    http_version: 
+  recorded_at: Mon, 04 Jul 2016 20:16:12 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Fixes #53 Make metrics aware of HWKMETRICS-24

HWKMETRICS-24 makes (incompatible) changes to some metrics endpoints.
The old endpoints still exist for a while, but will go away. We may check if h-metrics has a working version endpoint and then decide which endpoint to call according to the version.
