### PR TITLE
Fix regression where URIs as input for the entrypoint no longer worked.

### DIFF
--- a/lib/hawkular/base_client.rb
+++ b/lib/hawkular/base_client.rb
@@ -140,10 +140,11 @@ module Hawkular
       strip_path.nil? || suffix_path = strip_path
       strip_path = suffix_path.gsub(%r{^/}, '')
       strip_path.nil? || suffix_path = strip_path
-      strip_entrypoint = entrypoint.to_s.gsub(%r{/$}, '')
-      strip_path.nil? && strip_entrypoint = entrypoint.to_s
+      entrypoint = entrypoint.to_s
+      strip_entrypoint = entrypoint.gsub(%r{/$}, '')
+      strip_path.nil? && strip_entrypoint = entrypoint
       relative_path_rgx = Regexp.new("\/#{Regexp.quote(suffix_path)}(\/)*$")
-      if relative_path_rgx.match(entrypoint.to_s)
+      if relative_path_rgx.match(entrypoint)
         strip_entrypoint
       else
         "#{strip_entrypoint}/#{suffix_path}"

--- a/lib/hawkular/base_client.rb
+++ b/lib/hawkular/base_client.rb
@@ -131,18 +131,19 @@ module Hawkular
     # also, this function always remove the slash at the end of the URL, so if your entrypoint is
     # http://localhost/hawkular/inventory/ this function will return http://localhost/hawkular/inventory
     # to the URL
-    # @param entrypoint [String] base path
+    # @param entrypoint [String] base path (URIs are also accepted)
     # @param suffix_path [String] sufix path to be added if it doesn't exist
     # @return [String] URL with path attached to it at the end
     def normalize_entrypoint_url(entrypoint, suffix_path)
+      fail ArgumentError, 'suffix_path must not be empty' if suffix_path.empty?
       strip_path = suffix_path.gsub(%r{/$}, '')
       strip_path.nil? || suffix_path = strip_path
       strip_path = suffix_path.gsub(%r{^/}, '')
       strip_path.nil? || suffix_path = strip_path
-      strip_entrypoint = entrypoint.gsub(%r{/$}, '')
-      strip_path.nil? && strip_entrypoint = entrypoint
+      strip_entrypoint = entrypoint.to_s.gsub(%r{/$}, '')
+      strip_path.nil? && strip_entrypoint = entrypoint.to_s
       relative_path_rgx = Regexp.new("\/#{Regexp.quote(suffix_path)}(\/)*$")
-      if relative_path_rgx.match(entrypoint)
+      if relative_path_rgx.match(entrypoint.to_s)
         strip_entrypoint
       else
         "#{strip_entrypoint}/#{suffix_path}"

--- a/spec/integration/hawkular_client_spec.rb
+++ b/spec/integration/hawkular_client_spec.rb
@@ -31,6 +31,32 @@ module Hawkular::Client::RSpec
       expect { @hawkular_client.inventory_lyst_feeds }.to raise_error(NoMethodError)
     end
 
+    context 'and URIs as input', vcr: { decode_compressed_response: true } do
+      it 'Should work with URI' do
+        uri = URI.parse HOST
+        opts = { tenant: 'hawkular' }
+
+        the_client = Hawkular::Client.new(entrypoint: uri, credentials: @creds, options: opts)
+        expect { the_client.inventory.list_feeds }.to_not raise_error
+      end
+
+      it 'Should work with URI on metrics client' do
+        uri = URI.parse HOST
+        opts = { tenant: 'hawkular' }
+
+        the_client = Hawkular::Metrics::Client.new(uri, @creds, opts)
+        expect { the_client.http_get '/status' }.to_not raise_error
+      end
+
+      it 'Should work with https URI on metrics client' do
+        uri = URI.parse 'https://localhost:8080'
+        opts = { tenant: 'hawkular' }
+
+        the_client = Hawkular::Metrics::Client.new(uri, @creds, opts)
+        expect !the_client.nil?
+      end
+    end
+
     context 'and Inventory client', vcr: { decode_compressed_response: true } do
       before(:all) do
         ::RSpec::Mocks.with_temporary_scope do

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -138,5 +138,21 @@ describe 'Base Spec' do
 
     ret = c.normalize_entrypoint_url 'http://127.0.0.1/hawkular/alerts/', 'hawkular/alerts'
     expect(ret).to eq('http://127.0.0.1/hawkular/alerts')
+
+    ret = c.normalize_entrypoint_url 'https://127.0.0.1/hawkular/alerts/', 'hawkular/alerts'
+    expect(ret).to eq('https://127.0.0.1/hawkular/alerts')
+
+    ret = c.normalize_entrypoint_url 'https://localhost:8080/', 'hawkular/alerts'
+    expect(ret).to eq('https://localhost:8080/hawkular/alerts')
+
+    expect { c.normalize_entrypoint_url 'https://localhost:8080/hawkular/alerts', '' }.to raise_error(ArgumentError)
+
+    uri = URI.parse 'https://localhost:8080/'
+    ret = c.normalize_entrypoint_url uri, 'hawkular/alerts'
+    expect(ret).to eq('https://localhost:8080/hawkular/alerts')
+
+    uri = URI.parse 'http://localhost:8080/hawkular/alerts/'
+    ret = c.normalize_entrypoint_url uri, '/hawkular/alerts/'
+    expect(ret).to eq('http://localhost:8080/hawkular/alerts')
   end
 end

--- a/spec/vcr_cassettes/HawkularClient/and_URIs_as_input/Should_work_with_URI.yml
+++ b/spec/vcr_cassettes/HawkularClient/and_URIs_as_input/Should_work_with_URI.yml
@@ -1,0 +1,112 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '234'
+      Date:
+      - Fri, 08 Jul 2016 10:39:13 GMT
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "Implementation-Version" : "0.17.2.Final",
+          "Built-From-Git-SHA1" : "3c8ac6648aa0ec33643ae1b98faadc475d2c6f02",
+          "Inventory-Implementation" : "org.hawkular.inventory.impl.tinkerpop.TinkerpopInventory",
+          "Initialized" : "true"
+        }
+    http_version: 
+  recorded_at: Fri, 08 Jul 2016 10:39:13 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/deprecated/feeds
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 08 Jul 2016 10:39:13 GMT
+      X-Total-Count:
+      - '2'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '542'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/deprecated/feeds>; rel="current"
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        [ {
+          "path" : "/t;hawkular/f;5f040b77-8929-46f4-ace2-4da64c370a0e",
+          "properties" : {
+            "__identityHash" : "5c76e6f66a08176a1e413e9acb433f534c3e31a"
+          },
+          "identityHash" : "5c76e6f66a08176a1e413e9acb433f534c3e31a",
+          "id" : "5f040b77-8929-46f4-ace2-4da64c370a0e"
+        }, {
+          "path" : "/t;hawkular/f;70c798a0-6985-4f8a-a525-012d8d28e8a3",
+          "properties" : {
+            "__identityHash" : "fe2613e3b6df7c9dadc6f314e1902b1395445ceb"
+          },
+          "identityHash" : "fe2613e3b6df7c9dadc6f314e1902b1395445ceb",
+          "id" : "70c798a0-6985-4f8a-a525-012d8d28e8a3"
+        } ]
+    http_version: 
+  recorded_at: Fri, 08 Jul 2016 10:39:13 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/HawkularClient/and_URIs_as_input/Should_work_with_URI_on_metrics_client.yml
+++ b/spec/vcr_cassettes/HawkularClient/and_URIs_as_input/Should_work_with_URI_on_metrics_client.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/status
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '133'
+      Date:
+      - Fri, 08 Jul 2016 10:39:13 GMT
+    body:
+      encoding: UTF-8
+      string: '{"MetricsService":"STARTED","Implementation-Version":"0.17.0.Final","Built-From-Git-SHA1":"c439d3797397425d340eac7c549e330d51fc2cac"}'
+    http_version: 
+  recorded_at: Fri, 08 Jul 2016 10:39:13 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Some normalization logic in 2.2.0 introduced a regression where URI:HTTP object were no longer accepted as input for entrypoints.
This pr checks for uri objects and converts them to string if needed.

@simon3z @yaacov
