### PR TITLE
Metric ID not escaped in MetricClient.update_tags

### DIFF
--- a/lib/hawkular/metrics/metric_api.rb
+++ b/lib/hawkular/metrics/metric_api.rb
@@ -79,14 +79,15 @@ module Hawkular::Metrics
       # @param id [String]
       # @return [MetricDefinition]
       def get(id)
-        the_id = @client.hawk_escape id
+        the_id = ERB::Util.url_encode id
         Hawkular::Metrics::MetricDefinition.new(@client.http_get("/#{@resource}/#{the_id}"))
       end
 
       # update tags for given metric definition
       # @param metric_definition [MetricDefinition]
       def update_tags(metric_definition)
-        @client.http_put("/#{@resource}/#{metric_definition.id}/tags", metric_definition.hash[:tags])
+        metric_definition_id = ERB::Util.url_encode metric_definition.id
+        @client.http_put("/#{@resource}/#{metric_definition_id}/tags", metric_definition.hash[:tags])
       end
 
       # Push metric data
@@ -106,7 +107,7 @@ module Hawkular::Metrics
         data = [data] unless data.is_a?(Array)
 
         @client.default_timestamp data
-        @client.http_post("/#{@resource}/#{id}/data", data)
+        @client.http_post("/#{@resource}/#{ERB::Util.url_encode(id)}/data", data)
       end
 
       # Retrieve metric datapoints
@@ -189,7 +190,7 @@ module Hawkular::Metrics
       #   client.gauges.get_periods("gauge1", starts: before4h, threshold: 10, operation: "lte")
       def get_periods(id, starts: nil, ends: nil, threshold: nil, operation: nil)
         params = { start: starts, end: ends, threshold: threshold, op: operation }
-        @client.http_get("/#{@resource}/#{id}/periods?" + encode_params(params))
+        @client.http_get("/#{@resource}/#{ERB::Util.url_encode(id)}/periods?" + encode_params(params))
       end
     end
 

--- a/spec/vcr_cassettes/Metric_ID_with_special_characters/Get_metric_definition_by_id.yml
+++ b/spec/vcr_cassettes/Metric_ID_with_special_characters/Get_metric_definition_by_id.yml
@@ -1,0 +1,49 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B8b*%7D%7B'%5C14%23%3F%2F5-7%2592e%5B-c9_.r1%2F%2F;%2F74eddf%2FL=c~~%5D~MT~%20%20%20%20*%20%20%2F%20Met@ics~Aggre&%3F%20ated%20s%20%20Active%22%20Ses;ns
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 11 Jul 2016 22:01:29 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '300'
+    body:
+      encoding: UTF-8
+      string: '{"id":"MI~R~[8b*}{''\\14#?/5-7%92e[-c9_.r1//;/74eddf/L=c~~]~MT~    *  /
+        Met@ics~Aggre&? ated s  Active\" Ses;ns","tags":{"name1":"value1","name2":"value2","name3":"value3","tag":"value"},"dataRetention":90,"type":"gauge","tenantId":"vcr-test","minTimestamp":1468274489807,"maxTimestamp":1468274489807}'
+    http_version: 
+  recorded_at: Mon, 11 Jul 2016 22:01:29 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metric_ID_with_special_characters/Retrieve_metric_rate_points.yml
+++ b/spec/vcr_cassettes/Metric_ID_with_special_characters/Retrieve_metric_rate_points.yml
@@ -1,0 +1,88 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B8b*%7D%7B'%5C14%23%3F%2F5-7%2592e%5B-c9_.r1%2F%2F;%2F74eddf%2FL=c~~%5D~MT~%20%20%20%20*%20%20%2F%20Met@ics~Aggre&%3F%20ated%20s%20%20Active%22%20Ses;ns
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 11 Jul 2016 22:03:24 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '242'
+    body:
+      encoding: UTF-8
+      string: '{"id":"MI~R~[8b*}{''\\14#?/5-7%92e[-c9_.r1//;/74eddf/L=c~~]~MT~    *  /
+        Met@ics~Aggre&? ated s  Active\" Ses;ns","tags":{"name1":"value1","name2":"value2","name3":"value3","tag":"value"},"dataRetention":90,"type":"gauge","tenantId":"vcr-test"}'
+    http_version: 
+  recorded_at: Mon, 11 Jul 2016 22:03:24 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/AA~R~%5B8b*%7D%7B'%5C14%23%3F%2F5-7%2592%5Bd-c9_.r1%2F%2F%2F7;:4eddf%2FL=c~~%5D~MT~%20%20%25-Met@ics~Aggre&%3Fated%20%22%20Sess%7Bons/rate
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 11 Jul 2016 22:03:25 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 11 Jul 2016 22:03:25 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metric_ID_with_special_characters/Should_create_Availability_definition.yml
+++ b/spec/vcr_cassettes/Metric_ID_with_special_characters/Should_create_Availability_definition.yml
@@ -1,0 +1,97 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability
+    body:
+      encoding: UTF-8
+      string: '{"id":"AA~R~[8b*}{''\\14#?/5-7%92[d-c9_.r1///7;:4eddf/L=c~~]~MT~ A  *  %-Met@ics~Aggre&?ated
+        \" Sess{ons","dataRetention":90,"tags":{"tag":"value"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '147'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/metrics/availability/AA~R~%5B8b*%7D%7B'%5C14%23%3F%2F5-7%2592%5Bd-c9_.r1%2F%2F%2F7;:4eddf%2FL=c~~%5D~MT~%20A%20%20*%20%20%25-Met@ics~Aggre&%3Fated%20%22%20Sess%7Bons
+      Date:
+      - Mon, 11 Jul 2016 22:01:29 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 11 Jul 2016 22:01:29 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/AA~R~%5B8b*%7D%7B'%5C14%23%3F%2F5-7%2592%5Bd-c9_.r1%2F%2F%2F7;:4eddf%2FL=c~~%5D~MT~%20A%20%20*%20%20%25-Met@ics~Aggre&%3Fated%20%22%20Sess%7Bons
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 11 Jul 2016 22:01:29 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '191'
+    body:
+      encoding: UTF-8
+      string: '{"id":"AA~R~[8b*}{''\\14#?/5-7%92[d-c9_.r1///7;:4eddf/L=c~~]~MT~ A  *  %-Met@ics~Aggre&?ated
+        \" Sess{ons","tags":{"tag":"value"},"dataRetention":90,"type":"availability","tenantId":"vcr-test"}'
+    http_version: 
+  recorded_at: Mon, 11 Jul 2016 22:01:29 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metric_ID_with_special_characters/Should_create_Counter_definition.yml
+++ b/spec/vcr_cassettes/Metric_ID_with_special_characters/Should_create_Counter_definition.yml
@@ -1,0 +1,97 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters
+    body:
+      encoding: UTF-8
+      string: '{"id":"AA~R~[8b*}{''\\14#?/5-7%92[d-c9_.r1///7;:4eddf/L=c~~]~MT~  %-Met@ics~Aggre&?ated
+        \" Sess{ons","dataRetention":90,"tags":{"tag":"value"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '142'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/metrics/counters/AA~R~%5B8b*%7D%7B'%5C14%23%3F%2F5-7%2592%5Bd-c9_.r1%2F%2F%2F7;:4eddf%2FL=c~~%5D~MT~%20%20%25-Met@ics~Aggre&%3Fated%20%22%20Sess%7Bons
+      Date:
+      - Mon, 11 Jul 2016 22:03:24 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 11 Jul 2016 22:03:24 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/counters/AA~R~%5B8b*%7D%7B'%5C14%23%3F%2F5-7%2592%5Bd-c9_.r1%2F%2F%2F7;:4eddf%2FL=c~~%5D~MT~%20%20%25-Met@ics~Aggre&%3Fated%20%22%20Sess%7Bons
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 11 Jul 2016 22:03:24 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '181'
+    body:
+      encoding: UTF-8
+      string: '{"id":"AA~R~[8b*}{''\\14#?/5-7%92[d-c9_.r1///7;:4eddf/L=c~~]~MT~  %-Met@ics~Aggre&?ated
+        \" Sess{ons","tags":{"tag":"value"},"dataRetention":90,"type":"counter","tenantId":"vcr-test"}'
+    http_version: 
+  recorded_at: Mon, 11 Jul 2016 22:03:24 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metric_ID_with_special_characters/Should_create_gauge_definition.yml
+++ b/spec/vcr_cassettes/Metric_ID_with_special_characters/Should_create_gauge_definition.yml
@@ -1,0 +1,97 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges
+    body:
+      encoding: UTF-8
+      string: '{"id":"MI~R~[8b*}{''\\14#?/5-7%92e[-c9_.r1//;/74eddf/L=c~~]~MT~    *  /
+        Met@ics~Aggre&? ated s  Active\" Ses;ns","dataRetention":90,"tags":{"tag":"value"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '154'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/metrics/gauges/MI~R~%5B8b*%7D%7B'%5C14%23%3F%2F5-7%2592e%5B-c9_.r1%2F%2F;%2F74eddf%2FL=c~~%5D~MT~%20%20%20%20*%20%20%2F%20Met@ics~Aggre&%3F%20ated%20s%20%20Active%22%20Ses;ns
+      Date:
+      - Mon, 11 Jul 2016 22:01:29 GMT
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 11 Jul 2016 22:01:29 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B8b*%7D%7B'%5C14%23%3F%2F5-7%2592e%5B-c9_.r1%2F%2F;%2F74eddf%2FL=c~~%5D~MT~%20%20%20%20*%20%20%2F%20Met@ics~Aggre&%3F%20ated%20s%20%20Active%22%20Ses;ns
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 11 Jul 2016 22:01:29 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '191'
+    body:
+      encoding: UTF-8
+      string: '{"id":"MI~R~[8b*}{''\\14#?/5-7%92e[-c9_.r1//;/74eddf/L=c~~]~MT~    *  /
+        Met@ics~Aggre&? ated s  Active\" Ses;ns","tags":{"tag":"value"},"dataRetention":90,"type":"gauge","tenantId":"vcr-test"}'
+    http_version: 
+  recorded_at: Mon, 11 Jul 2016 22:01:29 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metric_ID_with_special_characters/Should_push_metric_data_to_existing_gauge.yml
+++ b/spec/vcr_cassettes/Metric_ID_with_special_characters/Should_push_metric_data_to_existing_gauge.yml
@@ -1,0 +1,48 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B8b*%7D%7B'%5C14%23%3F%2F5-7%2592e%5B-c9_.r1%2F%2F;%2F74eddf%2FL=c~~%5D~MT~%20%20%20%20*%20%20%2F%20Met@ics~Aggre&%3F%20ated%20s%20%20Active%22%20Ses;ns/data
+    body:
+      encoding: UTF-8
+      string: '[{"value":0.1,"tags":{"tagName":"myMin"},"timestamp":1468274489807},{"value":99.9,"tags":{"tagName":"myMax"},"timestamp":1468274489807}]'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '136'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 11 Jul 2016 22:01:29 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 11 Jul 2016 22:01:29 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metric_ID_with_special_characters/Should_update_tags_for_Availability_definition.yml
+++ b/spec/vcr_cassettes/Metric_ID_with_special_characters/Should_update_tags_for_Availability_definition.yml
@@ -1,0 +1,140 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/AA~R~%5B8b*%7D%7B'%5C14%23%3F%2F5-7%2592%5Bd-c9_.r1%2F%2F%2F7;:4eddf%2FL=c~~%5D~MT~%20A%20%20*%20%20%25-Met@ics~Aggre&%3Fated%20%22%20Sess%7Bons
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 11 Jul 2016 22:01:29 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '191'
+    body:
+      encoding: UTF-8
+      string: '{"id":"AA~R~[8b*}{''\\14#?/5-7%92[d-c9_.r1///7;:4eddf/L=c~~]~MT~ A  *  %-Met@ics~Aggre&?ated
+        \" Sess{ons","tags":{"tag":"value"},"dataRetention":90,"type":"availability","tenantId":"vcr-test"}'
+    http_version: 
+  recorded_at: Mon, 11 Jul 2016 22:01:29 GMT
+- request:
+    method: put
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/AA~R~%5B8b*%7D%7B'%5C14%23%3F%2F5-7%2592%5Bd-c9_.r1%2F%2F%2F7;:4eddf%2FL=c~~%5D~MT~%20A%20%20*%20%20%25-Met@ics~Aggre&%3Fated%20%22%20Sess%7Bons/tags
+    body:
+      encoding: UTF-8
+      string: '{"name1":"value1","name2":"value2","name3":"value3"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '52'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 11 Jul 2016 22:01:29 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 11 Jul 2016 22:01:29 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/AA~R~%5B8b*%7D%7B'%5C14%23%3F%2F5-7%2592%5Bd-c9_.r1%2F%2F%2F7;:4eddf%2FL=c~~%5D~MT~%20A%20%20*%20%20%25-Met@ics~Aggre&%3Fated%20%22%20Sess%7Bons
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 11 Jul 2016 22:01:29 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '242'
+    body:
+      encoding: UTF-8
+      string: '{"id":"AA~R~[8b*}{''\\14#?/5-7%92[d-c9_.r1///7;:4eddf/L=c~~]~MT~ A  *  %-Met@ics~Aggre&?ated
+        \" Sess{ons","tags":{"name1":"value1","name2":"value2","name3":"value3","tag":"value"},"dataRetention":90,"type":"availability","tenantId":"vcr-test"}'
+    http_version: 
+  recorded_at: Mon, 11 Jul 2016 22:01:29 GMT
+recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metric_ID_with_special_characters/Should_update_tags_for_gauge_definition.yml
+++ b/spec/vcr_cassettes/Metric_ID_with_special_characters/Should_update_tags_for_gauge_definition.yml
@@ -1,0 +1,140 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B8b*%7D%7B'%5C14%23%3F%2F5-7%2592e%5B-c9_.r1%2F%2F;%2F74eddf%2FL=c~~%5D~MT~%20%20%20%20*%20%20%2F%20Met@ics~Aggre&%3F%20ated%20s%20%20Active%22%20Ses;ns
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 11 Jul 2016 22:01:29 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '249'
+    body:
+      encoding: UTF-8
+      string: '{"id":"MI~R~[8b*}{''\\14#?/5-7%92e[-c9_.r1//;/74eddf/L=c~~]~MT~    *  /
+        Met@ics~Aggre&? ated s  Active\" Ses;ns","tags":{"tag":"value"},"dataRetention":90,"type":"gauge","tenantId":"vcr-test","minTimestamp":1468274489807,"maxTimestamp":1468274489807}'
+    http_version: 
+  recorded_at: Mon, 11 Jul 2016 22:01:29 GMT
+- request:
+    method: put
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B8b*%7D%7B'%5C14%23%3F%2F5-7%2592e%5B-c9_.r1%2F%2F;%2F74eddf%2FL=c~~%5D~MT~%20%20%20%20*%20%20%2F%20Met@ics~Aggre&%3F%20ated%20s%20%20Active%22%20Ses;ns/tags
+    body:
+      encoding: UTF-8
+      string: '{"name1":"value1","name2":"value2","name3":"value3"}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '52'
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 11 Jul 2016 22:01:29 GMT
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Mon, 11 Jul 2016 22:01:29 GMT
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/MI~R~%5B8b*%7D%7B'%5C14%23%3F%2F5-7%2592e%5B-c9_.r1%2F%2F;%2F74eddf%2FL=c~~%5D~MT~%20%20%20%20*%20%20%2F%20Met@ics~Aggre&%3F%20ated%20s%20%20Active%22%20Ses;ns
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Hawkular-Tenant:
+      - vcr-test
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Mon, 11 Jul 2016 22:01:29 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '300'
+    body:
+      encoding: UTF-8
+      string: '{"id":"MI~R~[8b*}{''\\14#?/5-7%92e[-c9_.r1//;/74eddf/L=c~~]~MT~    *  /
+        Met@ics~Aggre&? ated s  Active\" Ses;ns","tags":{"name1":"value1","name2":"value2","name3":"value3","tag":"value"},"dataRetention":90,"type":"gauge","tenantId":"vcr-test","minTimestamp":1468274489807,"maxTimestamp":1468274489807}'
+    http_version: 
+  recorded_at: Mon, 11 Jul 2016 22:01:29 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Sometimes the metric ID contains special characters like`"/ & ?"` in some methods, those characters had not escaped properly.  When RestClient tries to parse the URL, it fails with an exception `bad URI(is not URI?):`

Fixes #109
