### PR TITLE
Add Errno::EADDRNOTAVAIL to list of potential connection errors.

### DIFF
--- a/lib/hawkular/base_client.rb
+++ b/lib/hawkular/base_client.rb
@@ -183,7 +183,8 @@ module Hawkular
       if fault.is_a?(SocketError)
         HawkularConnectionException.new(fault.to_s)
       elsif [Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EHOSTUNREACH,
-             Errno::ENETDOWN, Errno::ENETUNREACH, Errno::ETIMEDOUT].include?(fault.class)
+             Errno::EADDRNOTAVAIL, Errno::ENETDOWN, Errno::ENETUNREACH,
+             Errno::ETIMEDOUT].include?(fault.class)
         HawkularConnectionException.new(fault.to_s, fault.class::Errno)
       end
     end


### PR DESCRIPTION
OS/X reports that 

```
      expected Hawkular::BaseClient::HawkularConnectionException, got #<Errno::EADDRNOTAVAIL: Can't assign requested address - connect(2) for "127.0.0.1" port 0> with backtrace:
         # /Users/hrupp/.rvm/gems/ruby-2.2.4/gems/rest-client-2.0.0/lib/restclient/request.rb:766:in `transmit'

```
