### PR TITLE
Make it explicit that we require rest client v2.

### DIFF
--- a/hawkularclient.gemspec
+++ b/hawkularclient.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_runtime_dependency('rest-client')
+  gem.add_runtime_dependency('rest-client', '~> 2.0.0')
   gem.add_runtime_dependency('websocket-client-simple', '~> 0.3.0')
   gem.add_runtime_dependency('addressable')
   gem.add_development_dependency('shoulda')


### PR DESCRIPTION
This follows ManageIQ.

@abonas Can you please verify and eventually merge?
