### PR TITLE
Expose metric.type.id

### DIFF
--- a/hawkularclient.gemspec
+++ b/hawkularclient.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('websocket-client-simple', '~> 0.3.0')
   gem.add_runtime_dependency('addressable')
   gem.add_development_dependency('shoulda')
-  gem.add_development_dependency('rspec-rails', '~> 3.0')
+  gem.add_development_dependency('rspec-rails', '~> 3.1')
   gem.add_development_dependency('rake', '< 11')
   gem.add_development_dependency('simple-websocket-vcr', '= 0.0.7')
   gem.add_development_dependency('yard')

--- a/lib/hawkular/inventory/entities.rb
+++ b/lib/hawkular/inventory/entities.rb
@@ -101,10 +101,13 @@ module Hawkular::Inventory
   class Metric < BaseEntity
     include MetricFields
 
+    attr_reader :type_id
+
     def initialize(metric_hash)
       super(metric_hash)
       @type = metric_hash['type']['type']
       @type_path = metric_hash['type']['path']
+      @type_id = metric_hash['type']['id']
       @unit = metric_hash['type']['unit']
       @collection_interval = metric_hash['type']['collectionInterval']
     end

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -292,6 +292,15 @@ module Hawkular::Inventory::RSpec
       expect(metrics.size).to be(14)
     end
 
+    it 'Should have the same requested metric type id' do
+      metric_type_id = 'Server Availability~Server Availability'
+      type_path = CanonicalPath.new(feed_id: feed_id, metric_type_id: hawk_escape_id(metric_type_id))
+      metrics = @client.list_metrics_for_metric_type(type_path)
+
+      expect(metrics.size).to be > 0
+      expect(metrics).to all(have_attributes(type_id: metric_type_id))
+    end
+
     it 'Should return config data of given resource' do
       resource_path = CanonicalPath.new(feed_id: feed_id, resource_ids: [hawk_escape_id('Local~~')])
       config = @client.get_config_data_for_resource(resource_path)

--- a/spec/vcr_cassettes/Inventory/inventory_0_17/Templates/Should_have_the_same_requested_metric_type_id.yml
+++ b/spec/vcr_cassettes/Inventory/inventory_0_17/Templates/Should_have_the_same_requested_metric_type_id.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://jdoe:password@localhost:8080/hawkular/inventory/traversal/f;<%= feed_uuid %>/mt;Server%20Availability~Server%20Availability/rl;defines/type=m
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Thu, 28 Jul 2016 00:09:29 GMT
+      X-Total-Count:
+      - '1'
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '876'
+      Link:
+      - <http://localhost:8080/hawkular/inventory/traversal/f;<%= feed_uuid %>/mt;Server%20Availability~Server%20Availability/rl;defines/type=m>;
+        rel="current"
+    body:
+      encoding: UTF-8
+      string: |-
+        [ {
+          "path" : "/t;hawkular/f;<%= feed_uuid %>/m;AI~R~%5B<%= feed_uuid %>%2FLocal~~%5D~AT~Server%20Availability~Server%20Availability",
+          "properties" : {
+            "__identityHash" : "fa194dbc2719bcccbda7a8546db986adeff870df"
+          },
+          "name" : "Server Availability~Server Availability",
+          "identityHash" : "fa194dbc2719bcccbda7a8546db986adeff870df",
+          "type" : {
+            "path" : "/t;hawkular/f;<%= feed_uuid %>/mt;Server%20Availability~Server%20Availability",
+            "name" : "Server Availability~Server Availability",
+            "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
+            "unit" : "NONE",
+            "type" : "AVAILABILITY",
+            "collectionInterval" : 30,
+            "id" : "Server Availability~Server Availability"
+          },
+          "id" : "AI~R~[<%= feed_uuid %>/Local~~]~AT~Server Availability~Server Availability"
+        } ]
+    http_version: 
+  recorded_at: Thu, 28 Jul 2016 00:09:29 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Before, the metric.name was also the same as the metric.type.id, but since [this](http://lists.jboss.org/pipermail/hawkular-dev/2016-July/002973.html) (see first point) it become a human readable value.

In ManageIQ we used said name to create a [mapping](https://github.com/ManageIQ/manageiq/blob/master/product/live_metrics/middleware_server.yaml). As we no longer can trust that value it needs to be updated to use the metric.type.id. Thus we need to expose it.
