### PR TITLE
hwkagent-120 Deployment undeploy required UndeployApplicationRequest

### DIFF
--- a/spec/integration/operations_spec.rb
+++ b/spec/integration/operations_spec.rb
@@ -327,11 +327,11 @@ module Hawkular::Operations::RSpec
                                resource_ids: [wf_server_resource_id, alerts_war_resource_id])
 
       undeploy = {
-        operationName: 'Undeploy',
-        resourcePath: path.to_s
+        resource_path: path.to_s,
+        deployment_name: 'hawkular-alerts-actions-email.war'
       }
       actual_data = {}
-      @client.invoke_generic_operation(undeploy) do |on|
+      @client.remove_deployment(undeploy) do |on|
         on.success do |data|
           actual_data[:data] = data
         end

--- a/spec/unit/canonical_path_spec.rb
+++ b/spec/unit/canonical_path_spec.rb
@@ -37,6 +37,15 @@ describe 'CanonicalPath' do
         .to be == CanonicalPath.new(tenant_id: 't1', environment_id: 'e1', resource_ids: %w(r1 r2 r3))
     end
 
+    it 'with resource hierarchy should be upable' do
+      expect(CanonicalPath.parse('/t;t1/f;f1/r;r1/r;r2/r;r3/r;r4/r;r5').up)
+        .to be == CanonicalPath.new(tenant_id: 't1', feed_id: 'f1', resource_ids: %w(r1 r2 r3 r4))
+      expect(CanonicalPath.parse('/t;t1/e;e1/r;r1').up)
+        .to be == CanonicalPath.new(tenant_id: 't1', environment_id: 'e1', resource_ids: [])
+      expect(CanonicalPath.parse('/t;t1/e;e1').up)
+        .to be == CanonicalPath.new(tenant_id: 't1', environment_id: 'e1', resource_ids: [])
+    end
+
     it 'should be identity when calling parse and then to_s' do
       path_str = '/t;t1/e;e1/r;r1/r;r2'
       path1 = CanonicalPath.parse(path_str)

--- a/spec/vcr_cassettes/Operation/Operation/Undeploy_should_be_performed_and_eventually_respond_with_success.json
+++ b/spec/vcr_cassettes/Operation/Operation/Undeploy_should_be_performed_and_eventually_respond_with_success.json
@@ -7,7 +7,7 @@
     },
     {
       "operation": "write",
-      "data": "ExecuteOperationRequest={\"operationName\":\"Undeploy\",\"resourcePath\":\"/t;hawkular/f;33f22c4a-445a-4f90-a25e-caeff9579a10/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war\",\"authentication\":{\"username\":\"jdoe\",\"password\":\"password\"}}"
+      "data": "UndeployApplicationRequest={\"resourcePath\":\"/t;hawkular/f;33f22c4a-445a-4f90-a25e-caeff9579a10/r;Local~~\",\"destinationFileName\":\"\hawkular-alerts-actions-email.war\",\"authentication\":{\"username\":\"jdoe\",\"password\":\"password\"}}"
     },
     {
       "operation": "read",
@@ -17,7 +17,7 @@
     {
       "operation": "read",
       "type": "text",
-      "data": "ExecuteOperationResponse={\"operationName\":\"Undeploy\",\"resourcePath\":\"/t;hawkular/f;33f22c4a-445a-4f90-a25e-caeff9579a10/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war\",\"destinationSessionId\":\"1j9HQbWoBj9RMQZIR0BwpnU3IkxoMwQ-O9_Cr1Ds\",\"status\":\"OK\",\"message\":\"Performed [Undeploy] on a [DMR Node] given by Inventory path [/t;hawkular/f;33f22c4a-445a-4f90-a25e-caeff9579a10/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war]\"}"
+      "data": "UndeployApplicationResponse={\"resourcePath\":\"/t;hawkular/f;33f22c4a-445a-4f90-a25e-caeff9579a10/r;Local~~\",\"destinationFileName\":\"\hawkular-alerts-actions-email.war\",\"destinationSessionId\":\"1j9HQbWoBj9RMQZIR0BwpnU3IkxoMwQ-O9_Cr1Ds\",\"status\":\"OK\",\"message\":\"Performed [Undeploy] on a [DMR Node] given by Inventory path [/t;hawkular/f;33f22c4a-445a-4f90-a25e-caeff9579a10/r;Local~~/r;Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war]\"}"
     },
     {
       "operation": "close"


### PR DESCRIPTION
Provide the infrastructure to perform deployment removal via the dedicated UndeployApplicationRequest/Response messages and not as a generic operation.  Note that this is done via the server level and not directly on the deployment itself.
- Add CanonicalPath.up utility method

@pilhuhn please review
