### PR TITLE
Don't try to parse params if no properties are passed. Fixes #131

### DIFF
--- a/lib/hawkular/inventory/entities.rb
+++ b/lib/hawkular/inventory/entities.rb
@@ -119,6 +119,7 @@ module Hawkular::Inventory
     def initialize(op_hash)
       super(op_hash)
       @params = {}
+      return if op_hash['properties'].nil?
       param_list = op_hash['properties']['params']
       return if param_list.nil?
       param_list.each do |p|

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -333,6 +333,8 @@ module Hawkular::Inventory::RSpec
       expect(shutdown_def.params).to include('restart')
       restart_param = shutdown_def.params.fetch 'restart'
       expect(restart_param['type']).to eq('bool')
+      resume_def = operation_definitions.fetch 'Resume'
+      expect(resume_def.params).to be {}
     end
 
     it 'Should list operation definitions of given resource' do

--- a/spec/vcr_cassettes/Inventory/inventory_0_17/Templates/Should_list_operation_definitions_of_given_resource_type.yml
+++ b/spec/vcr_cassettes/Inventory/inventory_0_17/Templates/Should_list_operation_definitions_of_given_resource_type.yml
@@ -66,9 +66,6 @@ http_interactions:
           "id" : "Reload"
         }, {
           "path" : "/t;hawkular/f;<%= feed_uuid %>/rt;WildFly%20Server/ot;Resume",
-          "properties" : {
-            "__identityHash" : "b5103168d783b0bb67bf88f30c1fad462b635e"
-          },
           "name" : "Resume",
           "identityHash" : "b5103168d783b0bb67bf88f30c1fad462b635e",
           "id" : "Resume"


### PR DESCRIPTION
Newer versions of inventory may not send properties hash if there are none.
Before an empty hash was sent.

cc @jmazzitelli 
