### PR TITLE
Exposes metric-id property if it exists.

### DIFF
--- a/lib/hawkular/inventory/entities.rb
+++ b/lib/hawkular/inventory/entities.rb
@@ -102,6 +102,8 @@ module Hawkular::Inventory
     include MetricFields
 
     attr_reader :type_id
+    # @return [String] metric id used in Hawkular Metrics
+    attr_reader :hawkular_metric_id
 
     def initialize(metric_hash)
       super(metric_hash)
@@ -110,6 +112,7 @@ module Hawkular::Inventory
       @type_id = metric_hash['type']['id']
       @unit = metric_hash['type']['unit']
       @collection_interval = metric_hash['type']['collectionInterval']
+      @hawkular_metric_id = @properties.key?('metric-id') ? @properties['metric-id'] : @id
     end
   end
 


### PR DESCRIPTION
Fixes #110 

I'm not sure if this is the right way to expose this id. Or if we should call it hawkular_metric_id or native_metric_id.

Other ways could to be replace the 'id' value, is the id used somewhere else?
