### PR TITLE
Add changelog for 2.7.0

### DIFF
--- a/CHANGES.rdoc
+++ b/CHANGES.rdoc
@@ -3,6 +3,11 @@
 This document describes the relevant changes between releases of the
 _hawkular-client_ project.
 
+=== V 2.7.0
+
+* Support for SSL connections
+* Fix fetching stats to support rates
+
 === V 2.6.0
 
 * Fix fetching operation params in the recommended way
@@ -10,8 +15,6 @@ _hawkular-client_ project.
 * Fix fetching configuration properties of a resource
 
 Full list of items can be found at https://github.com/hawkular/hawkular-client-ruby/milestone/11?closed=1
-
-
 
 === V 2.5.0
 

--- a/lib/hawkular/version.rb
+++ b/lib/hawkular/version.rb
@@ -4,5 +4,5 @@
 # @see https://github.com/hawkular
 module Hawkular
   # Version of the Hawkular Ruby Gem
-  VERSION = '2.6.0'.freeze
+  VERSION = '2.7.0'.freeze
 end


### PR DESCRIPTION
@josejulio @theute @rubenvp8510 
/cc @abonas 
I have added a changelog for 2.6.1 and bumped the versioning.
I have never release the gem, so I am not sure if this is enough or if we need additional steps.

Also, I have doubt if we should bump to 2.6.1 or 2.7.
Perhaps the SSL and the fix are relatively minor changes from end user.
But anyway, if criteria is to bump 2.7 please let me know and I will modify the number.
