### PR TITLE
Corrects the hawkular-metric-id naming.

### DIFF
--- a/lib/hawkular/inventory/entities.rb
+++ b/lib/hawkular/inventory/entities.rb
@@ -112,7 +112,7 @@ module Hawkular::Inventory
       @type_id = metric_hash['type']['id']
       @unit = metric_hash['type']['unit']
       @collection_interval = metric_hash['type']['collectionInterval']
-      @hawkular_metric_id = @properties.key?('metric-id') ? @properties['metric-id'] : @id
+      @hawkular_metric_id = @properties.key?('hawkular-metric-id') ? @properties['hawkular-metric-id'] : @id
     end
   end
 


### PR DESCRIPTION
In #140 we agreed to rename metric-id to hawkular-metric-id.
Forgot to update this string, thus this PR.
