### PR TITLE
Fixes get_entity call.

### DIFF
--- a/lib/hawkular/inventory/inventory_api.rb
+++ b/lib/hawkular/inventory/inventory_api.rb
@@ -194,7 +194,7 @@ module Hawkular::Inventory
     # @return inventory entity
     def get_entity(path)
       c_path = path.is_a?(CanonicalPath) ? path : CanonicalPath.parse(path)
-      http_get("/entity/#{c_path}")
+      http_get("/entity#{c_path}")
     end
 
     # List the metrics for the passed metric type. If feed is not passed in the path,

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -522,6 +522,18 @@ module Hawkular::Inventory::RSpec
           expect(r2.properties).not_to be_empty
         end
 
+        it 'Should return data from get_entity' do
+          new_feed_id = 'feed_may_exist'
+          @client.create_feed new_feed_id
+          ret = @client.create_resource_type new_feed_id, 'dummy-resource-type', 'ResourceType'
+          type_path = ret.path
+          entity = @client.get_entity(type_path)
+
+          expect(entity['path']).to eq(type_path)
+          expect(entity['name']).to eq('ResourceType')
+          expect(entity['id']).to eq('dummy-resource-type')
+        end
+
         it 'Should not find an unknown resource' do
           new_feed_id = 'feed_may_exist'
           path = Hawkular::Inventory::CanonicalPath.new(

--- a/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_return_data_from_get_entity.yml
+++ b/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_return_data_from_get_entity.yml
@@ -1,0 +1,230 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://<%= super_secret_username %>:<%= super_secret_password %>@localhost:8080/hawkular/inventory/entity/feed
+    body:
+      encoding: UTF-8
+      string: '{"properties":{},"id":"feed_may_exist","name":null,"outgoing":{},"incoming":{}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '79'
+      Host:
+      - localhost:8080
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/inventory/entity/f;feed_may_exist
+      Date:
+      - Fri, 28 Oct 2016 16:25:46 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '253'
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "path" : "/t;hawkular/f;feed_may_exist",
+          "identityHash" : "18a4f8a18a8012f826e2dbe4cb768d14c391a59b",
+          "contentHash" : "da39a3ee5e6b4bd3255bfef95601890afd879",
+          "syncHash" : "2ca9805996fab3645d34da81df5aec62ef33e81a",
+          "id" : "feed_may_exist"
+        }
+    http_version: 
+  recorded_at: Fri, 28 Oct 2016 16:25:46 GMT
+- request:
+    method: post
+    uri: http://<%= super_secret_username %>:<%= super_secret_password %>@localhost:8080/hawkular/inventory/entity/f;feed_may_exist/resourceType
+    body:
+      encoding: UTF-8
+      string: '{"properties":{},"id":"dummy-resource-type","name":"ResourceType","outgoing":{},"incoming":{}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '94'
+      Host:
+      - localhost:8080
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Location:
+      - http://localhost:8080/hawkular/inventory/entity/f;feed_may_exist/rt;dummy-resource-type
+      Date:
+      - Fri, 28 Oct 2016 16:25:47 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "path" : "/t;hawkular/f;feed_may_exist/rt;dummy-resource-type",
+          "name" : "ResourceType",
+          "identityHash" : "11d3cc58d0797a6b2e6830f2fa3ba1e16c8d1b",
+          "contentHash" : "1b49accb63cf5aa916f3ee6d952a85fe27725b",
+          "syncHash" : "c6078bb6a5a25863918f5b93a1751564b2eb12",
+          "id" : "dummy-resource-type"
+        }
+    http_version: 
+  recorded_at: Fri, 28 Oct 2016 16:25:47 GMT
+- request:
+    method: get
+    uri: http://<%= super_secret_username %>:<%= super_secret_password %>@localhost:8080/hawkular/inventory/entity/f;feed_may_exist/rt;dummy-resource-type
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 28 Oct 2016 16:25:47 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "path" : "/t;hawkular/f;feed_may_exist/rt;dummy-resource-type",
+          "name" : "ResourceType",
+          "identityHash" : "11d3cc58d0797a6b2e6830f2fa3ba1e16c8d1b",
+          "contentHash" : "1b49accb63cf5aa916f3ee6d952a85fe27725b",
+          "syncHash" : "c6078bb6a5a25863918f5b93a1751564b2eb12",
+          "id" : "dummy-resource-type"
+        }
+    http_version: 
+  recorded_at: Fri, 28 Oct 2016 16:25:47 GMT
+- request:
+    method: get
+    uri: http://<%= super_secret_username %>:<%= super_secret_password %>@localhost:8080/hawkular/inventory/entity/t;hawkular/f;feed_may_exist/rt;dummy-resource-type
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Fri, 28 Oct 2016 16:25:47 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '305'
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "path" : "/t;hawkular/f;feed_may_exist/rt;dummy-resource-type",
+          "name" : "ResourceType",
+          "identityHash" : "11d3cc58d0797a6b2e6830f2fa3ba1e16c8d1b",
+          "contentHash" : "1b49accb63cf5aa916f3ee6d952a85fe27725b",
+          "syncHash" : "c6078bb6a5a25863918f5b93a1751564b2eb12",
+          "id" : "dummy-resource-type"
+        }
+    http_version: 
+  recorded_at: Fri, 28 Oct 2016 16:25:47 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
`CanonicalPath.to_s` starts with a '/' thus the url has
consecutive slashes and Hawkular fails to parse that
path.
