### PR TITLE
Update inventory client to match REST API: metricDataType

### DIFF
--- a/lib/hawkular/inventory/entities.rb
+++ b/lib/hawkular/inventory/entities.rb
@@ -91,7 +91,7 @@ module Hawkular::Inventory
 
     def initialize(type_hash)
       super(type_hash)
-      @type = type_hash['type']
+      @type = type_hash['metricDataType']
       @unit = type_hash['unit']
       @collection_interval = type_hash['collectionInterval']
     end
@@ -107,7 +107,7 @@ module Hawkular::Inventory
 
     def initialize(metric_hash)
       super(metric_hash)
-      @type = metric_hash['type']['type']
+      @type = metric_hash['type']['metricDataType']
       @type_path = metric_hash['type']['path']
       @type_id = metric_hash['type']['id']
       @unit = metric_hash['type']['unit']

--- a/lib/hawkular/inventory/entities.rb
+++ b/lib/hawkular/inventory/entities.rb
@@ -75,7 +75,7 @@ module Hawkular::Inventory
 
   # Fields that are common for MetricType and Metric
   module MetricFields
-    # @return [String] GAUGE, COUNTER, etc.
+    # @return [String] gauge, counter, etc.
     attr_reader :type
     # @return [String] metric unit such as NONE, BYTES, etc.
     attr_reader :unit

--- a/lib/hawkular/inventory/inventory_api.rb
+++ b/lib/hawkular/inventory/inventory_api.rb
@@ -243,14 +243,14 @@ module Hawkular::Inventory
     #   result by a filter to only return a subset. The
     # @param [String] resource_path Canonical path of the resource.
     # @param [Hash{Symbol=>String}] filter for 'type' and 'match'
-    #   Metric type can be one of 'GAUGE', 'COUNTER', 'AVAILABILITY'. If a key is missing
+    #   Metric type can be one of 'gauge', 'counter', 'availability'. If a key is missing
     #   it will not be used for filtering
     # @return [Array<Metric>] List of metrics that can be empty.
     # @example
     #    # Filter by type and match on metrics id
-    #    client.list_metrics_for_resource(wild_fly, type: 'GAUGE', match: 'Metrics~Heap')
+    #    client.list_metrics_for_resource(wild_fly, type: 'gauge', match: 'Metrics~Heap')
     #    # Filter by type only
-    #    client.list_metrics_for_resource(wild_fly, type: 'COUNTER')
+    #    client.list_metrics_for_resource(wild_fly, type: 'counter')
     #    # Don't filter, return all metric definitions
     #    client.list_metrics_for_resource(wild_fly)
     def list_metrics_for_resource(resource_path, filter = {})
@@ -381,15 +381,15 @@ module Hawkular::Inventory
     # Create a new metric type for a feed
     # @param [String] feed_id Id of the feed
     # @param [String] metric_type_id Id of the metric type to create
-    # @param [String] type Type of the Metric. Allowed are GAUGE,COUNTER, AVAILABILITY
+    # @param [String] type Type of the Metric. Allowed are gauge, counter, availability
     # @param [String] unit Unit of the metric
     # @param [Numeric] collection_interval
     # @return [MetricType] Type just created or the one from the server if it already existed.
-    def create_metric_type(feed_id, metric_type_id, type = 'GAUGE', unit = 'NONE', collection_interval = 60)
+    def create_metric_type(feed_id, metric_type_id, type = 'gauge', unit = 'NONE', collection_interval = 60)
       the_feed = hawk_escape_id feed_id
 
-      metric_kind = type.nil? ? 'GAUGE' : type.upcase
-      fail "Unknown type #{metric_kind}" unless %w(GAUGE COUNTER AVAILABILITY').include?(metric_kind)
+      metric_kind = type.nil? ? 'gauge' : type.downcase
+      fail "Unknown type #{metric_kind}" unless %w(gauge counter availability').include?(metric_kind)
 
       mt = build_metric_type_hash(collection_interval, metric_kind, metric_type_id, unit)
 

--- a/lib/hawkular/inventory/inventory_api.rb
+++ b/lib/hawkular/inventory/inventory_api.rb
@@ -539,7 +539,7 @@ module Hawkular::Inventory
     def build_metric_type_hash(collection_interval, metric_kind, metric_type_id, unit)
       mt = {}
       mt['id'] = metric_type_id
-      mt['type'] = metric_kind
+      mt['metricDataType'] = metric_kind
       mt['unit'] = unit.nil? ? 'NONE' : unit.upcase
       mt['collectionInterval'] = collection_interval.nil? ? 60 : collection_interval
       mt

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -307,13 +307,13 @@ module Hawkular::Inventory::RSpec
           resources = @client.list_resources_for_type(wildfly_type.to_s)
           wild_fly = resources[0]
 
-          metrics = @client.list_metrics_for_resource(wild_fly.path, type: 'GAUGE', match: 'Metrics~Heap')
+          metrics = @client.list_metrics_for_resource(wild_fly.path, type: 'gauge', match: 'Metrics~Heap')
           expect(metrics.size).to be(3)
 
           metrics = @client.list_metrics_for_resource(wild_fly.path, match: 'Metrics~Heap')
           expect(metrics.size).to be(3)
 
-          metrics = @client.list_metrics_for_resource(wild_fly.path, type: 'GAUGE')
+          metrics = @client.list_metrics_for_resource(wild_fly.path, type: 'gauge')
           expect(metrics.size).to be(8)
         end
 
@@ -547,7 +547,7 @@ module Hawkular::Inventory::RSpec
           new_feed_id = 'feed_may_exist'
 
           expect { @client.create_metric_type new_feed_id, 'abc', 'FOOBaR' }.to raise_error(RuntimeError,
-                                                                                            /Unknown type FOOBAR/)
+                                                                                            /Unknown type foobar/)
         end
 
         let(:example) do |e|

--- a/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_create_a_nested_resource_and_metric_on_it.yml
+++ b/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_create_a_nested_resource_and_metric_on_it.yml
@@ -54,7 +54,7 @@ http_interactions:
           "identityHash" : "353d88f09127d8b924e48c6daf58ee242f5fdf",
           "id" : "NonSecure_feed_may_exist"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:39 GMT
 - request:
     method: post
@@ -111,7 +111,7 @@ http_interactions:
           "identityHash" : "5c475fba1eab01a3f0fbabfbe0efac752aeb7",
           "id" : "rt-123-1"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:39 GMT
 - request:
     method: get
@@ -164,7 +164,7 @@ http_interactions:
           "identityHash" : "5c475fba1eab01a3f0fbabfbe0efac752aeb7",
           "id" : "rt-123-1"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:39 GMT
 - request:
     method: post
@@ -227,7 +227,7 @@ http_interactions:
           },
           "id" : "r124-a"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:39 GMT
 - request:
     method: post
@@ -290,14 +290,14 @@ http_interactions:
           },
           "id" : "r124-b"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:39 GMT
 - request:
     method: post
     uri: http://<%= super_secret_username %>:<%= super_secret_password %>@localhost:8080/hawkular/inventory/entity/f;NonSecure_feed_may_exist/metricType
     body:
       encoding: UTF-8
-      string: '{"id":"mt-124-a","type":"GAUGE","unit":"NONE","collectionInterval":60}'
+      string: '{"id":"mt-124-a","metricDataType":"GAUGE","unit":"NONE","collectionInterval":60}'
     headers:
       Accept:
       - application/json
@@ -345,11 +345,11 @@ http_interactions:
           "path" : "/t;hawkular/f;NonSecure_feed_may_exist/mt;mt-124-a",
           "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
           "unit" : "NONE",
-          "type" : "GAUGE",
+          "metricDataType" : "GAUGE",
           "collectionInterval" : 60,
           "id" : "mt-124-a"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:39 GMT
 - request:
     method: get
@@ -400,11 +400,11 @@ http_interactions:
           "path" : "/t;hawkular/f;NonSecure_feed_may_exist/mt;mt-124-a",
           "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
           "unit" : "NONE",
-          "type" : "GAUGE",
+          "metricDataType" : "GAUGE",
           "collectionInterval" : 60,
           "id" : "mt-124-a"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:39 GMT
 - request:
     method: post
@@ -463,13 +463,13 @@ http_interactions:
             "path" : "/t;hawkular/f;NonSecure_feed_may_exist/mt;mt-124-a",
             "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "mt-124-a"
           },
           "id" : "m-124-a"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:39 GMT
 - request:
     method: get
@@ -527,13 +527,13 @@ http_interactions:
             "path" : "/t;hawkular/f;NonSecure_feed_may_exist/mt;mt-124-a",
             "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "mt-124-a"
           },
           "id" : "m-124-a"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:39 GMT
 - request:
     method: post
@@ -590,7 +590,7 @@ http_interactions:
           "source" : "/t;hawkular/f;NonSecure_feed_may_exist/r;r124-a/r;r124-b",
           "target" : "/t;hawkular/f;NonSecure_feed_may_exist/m;m-124-a"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:39 GMT
 - request:
     method: get
@@ -653,12 +653,12 @@ http_interactions:
             "path" : "/t;hawkular/f;NonSecure_feed_may_exist/mt;mt-124-a",
             "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "mt-124-a"
           },
           "id" : "m-124-a"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:39 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_create_a_nested_resource_and_metric_on_it.yml
+++ b/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_create_a_nested_resource_and_metric_on_it.yml
@@ -297,7 +297,7 @@ http_interactions:
     uri: http://<%= super_secret_username %>:<%= super_secret_password %>@localhost:8080/hawkular/inventory/entity/f;NonSecure_feed_may_exist/metricType
     body:
       encoding: UTF-8
-      string: '{"id":"mt-124-a","metricDataType":"GAUGE","unit":"NONE","collectionInterval":60}'
+      string: '{"id":"mt-124-a","metricDataType":"gauge","unit":"NONE","collectionInterval":60}'
     headers:
       Accept:
       - application/json
@@ -345,7 +345,7 @@ http_interactions:
           "path" : "/t;hawkular/f;NonSecure_feed_may_exist/mt;mt-124-a",
           "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
           "unit" : "NONE",
-          "metricDataType" : "GAUGE",
+          "metricDataType" : "gauge",
           "collectionInterval" : 60,
           "id" : "mt-124-a"
         }
@@ -400,7 +400,7 @@ http_interactions:
           "path" : "/t;hawkular/f;NonSecure_feed_may_exist/mt;mt-124-a",
           "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
           "unit" : "NONE",
-          "metricDataType" : "GAUGE",
+          "metricDataType" : "gauge",
           "collectionInterval" : 60,
           "id" : "mt-124-a"
         }
@@ -463,7 +463,7 @@ http_interactions:
             "path" : "/t;hawkular/f;NonSecure_feed_may_exist/mt;mt-124-a",
             "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "mt-124-a"
           },
@@ -527,7 +527,7 @@ http_interactions:
             "path" : "/t;hawkular/f;NonSecure_feed_may_exist/mt;mt-124-a",
             "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "mt-124-a"
           },
@@ -653,7 +653,7 @@ http_interactions:
             "path" : "/t;hawkular/f;NonSecure_feed_may_exist/mt;mt-124-a",
             "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "mt-124-a"
           },

--- a/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_create_a_resource_with_metric.yml
+++ b/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_create_a_resource_with_metric.yml
@@ -362,7 +362,7 @@ http_interactions:
     uri: http://<%= super_secret_username %>:<%= super_secret_password %>@localhost:8080/hawkular/inventory/entity/f;feed_may_exist/metricType
     body:
       encoding: UTF-8
-      string: '{"id":"mt-124","metricDataType":"GAUGE","unit":"NONE","collectionInterval":60}'
+      string: '{"id":"mt-124","metricDataType":"gauge","unit":"NONE","collectionInterval":60}'
     headers:
       Accept:
       - application/json
@@ -410,7 +410,7 @@ http_interactions:
           "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
           "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
           "unit" : "NONE",
-          "metricDataType" : "GAUGE",
+          "metricDataType" : "gauge",
           "collectionInterval" : 60,
           "id" : "mt-124"
         }
@@ -465,7 +465,7 @@ http_interactions:
           "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
           "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
           "unit" : "NONE",
-          "metricDataType" : "GAUGE",
+          "metricDataType" : "gauge",
           "collectionInterval" : 60,
           "id" : "mt-124"
         }
@@ -528,7 +528,7 @@ http_interactions:
             "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
             "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "mt-124"
           },
@@ -592,7 +592,7 @@ http_interactions:
             "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
             "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "mt-124"
           },
@@ -714,7 +714,7 @@ http_interactions:
             "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
             "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "mt-124"
           },
@@ -778,7 +778,7 @@ http_interactions:
             "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
             "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "mt-124"
           },

--- a/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_create_a_resource_with_metric.yml
+++ b/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_create_a_resource_with_metric.yml
@@ -65,7 +65,7 @@ http_interactions:
             } ] ]
           }
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:38 GMT
 - request:
     method: get
@@ -120,7 +120,7 @@ http_interactions:
           "identityHash" : "74c06ecbd9cadebfda6338c1333995f6cc55b",
           "id" : "feed_may_exist"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:38 GMT
 - request:
     method: post
@@ -173,7 +173,7 @@ http_interactions:
           "errorMsg" : "Entity with id 'null' already exists at some of the positions: null",
           "details" : { }
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:38 GMT
 - request:
     method: get
@@ -226,7 +226,7 @@ http_interactions:
           "identityHash" : "30a52c53a93cb102e499367ecc55ed8a03b0b1",
           "id" : "rt-123"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:38 GMT
 - request:
     method: post
@@ -292,7 +292,7 @@ http_interactions:
           },
           "id" : "r124"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:38 GMT
 - request:
     method: get
@@ -355,14 +355,14 @@ http_interactions:
           },
           "id" : "r124"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:38 GMT
 - request:
     method: post
     uri: http://<%= super_secret_username %>:<%= super_secret_password %>@localhost:8080/hawkular/inventory/entity/f;feed_may_exist/metricType
     body:
       encoding: UTF-8
-      string: '{"id":"mt-124","type":"GAUGE","unit":"NONE","collectionInterval":60}'
+      string: '{"id":"mt-124","metricDataType":"GAUGE","unit":"NONE","collectionInterval":60}'
     headers:
       Accept:
       - application/json
@@ -410,11 +410,11 @@ http_interactions:
           "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
           "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
           "unit" : "NONE",
-          "type" : "GAUGE",
+          "metricDataType" : "GAUGE",
           "collectionInterval" : 60,
           "id" : "mt-124"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:38 GMT
 - request:
     method: get
@@ -465,11 +465,11 @@ http_interactions:
           "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
           "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
           "unit" : "NONE",
-          "type" : "GAUGE",
+          "metricDataType" : "GAUGE",
           "collectionInterval" : 60,
           "id" : "mt-124"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:38 GMT
 - request:
     method: post
@@ -528,13 +528,13 @@ http_interactions:
             "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
             "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "mt-124"
           },
           "id" : "m-124"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:38 GMT
 - request:
     method: get
@@ -592,13 +592,13 @@ http_interactions:
             "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
             "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "mt-124"
           },
           "id" : "m-124"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:38 GMT
 - request:
     method: post
@@ -655,7 +655,7 @@ http_interactions:
           "source" : "/t;hawkular/f;feed_may_exist/r;r124",
           "target" : "/t;hawkular/f;feed_may_exist/m;m-124"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:38 GMT
 - request:
     method: post
@@ -714,13 +714,13 @@ http_interactions:
             "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
             "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "mt-124"
           },
           "id" : "m-124-1"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:38 GMT
 - request:
     method: get
@@ -778,13 +778,13 @@ http_interactions:
             "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
             "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "mt-124"
           },
           "id" : "m-124-1"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:38 GMT
 - request:
     method: post
@@ -841,6 +841,6 @@ http_interactions:
           "source" : "/t;hawkular/f;feed_may_exist/r;r124",
           "target" : "/t;hawkular/f;feed_may_exist/m;m-124-1"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:38 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_have_the_same_requested_metric_type_id.yml
+++ b/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_have_the_same_requested_metric_type_id.yml
@@ -62,7 +62,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "metricDataType" : "AVAILABILITY",
+            "metricDataType" : "availability",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },

--- a/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_have_the_same_requested_metric_type_id.yml
+++ b/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_have_the_same_requested_metric_type_id.yml
@@ -62,12 +62,12 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "type" : "AVAILABILITY",
+            "metricDataType" : "AVAILABILITY",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
           "id" : "AI~R~[<%= feed_uuid %>/Local~~]~AT~Server Availability~Server Availability"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:37 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_list_heap_metrics_for_WildFlys.yml
+++ b/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_list_heap_metrics_for_WildFlys.yml
@@ -129,7 +129,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "metricDataType" : "AVAILABILITY",
+            "metricDataType" : "availability",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -146,7 +146,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -163,7 +163,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -180,7 +180,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -197,7 +197,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -214,7 +214,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -231,7 +231,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -248,7 +248,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -265,7 +265,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -282,7 +282,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -299,7 +299,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -316,7 +316,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -333,7 +333,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -350,7 +350,7 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },
@@ -420,7 +420,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "metricDataType" : "AVAILABILITY",
+            "metricDataType" : "availability",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -437,7 +437,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -454,7 +454,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -471,7 +471,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -488,7 +488,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -505,7 +505,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -522,7 +522,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -539,7 +539,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -556,7 +556,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -573,7 +573,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -590,7 +590,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -607,7 +607,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -624,7 +624,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -641,7 +641,7 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },
@@ -711,7 +711,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "metricDataType" : "AVAILABILITY",
+            "metricDataType" : "availability",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -728,7 +728,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -745,7 +745,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -762,7 +762,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -779,7 +779,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -796,7 +796,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -813,7 +813,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -830,7 +830,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -847,7 +847,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -864,7 +864,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -881,7 +881,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -898,7 +898,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -915,7 +915,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -932,7 +932,7 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },

--- a/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_list_heap_metrics_for_WildFlys.yml
+++ b/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_list_heap_metrics_for_WildFlys.yml
@@ -65,7 +65,7 @@ http_interactions:
           },
           "id" : "Local~~"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:37 GMT
 - request:
     method: get
@@ -129,7 +129,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "type" : "AVAILABILITY",
+            "metricDataType" : "AVAILABILITY",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -146,7 +146,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -163,7 +163,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -180,7 +180,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -197,7 +197,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -214,7 +214,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -231,7 +231,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -248,7 +248,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -265,7 +265,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -282,7 +282,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -299,7 +299,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -316,7 +316,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -333,7 +333,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -350,13 +350,13 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:37 GMT
 - request:
     method: get
@@ -420,7 +420,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "type" : "AVAILABILITY",
+            "metricDataType" : "AVAILABILITY",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -437,7 +437,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -454,7 +454,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -471,7 +471,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -488,7 +488,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -505,7 +505,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -522,7 +522,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -539,7 +539,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -556,7 +556,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -573,7 +573,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -590,7 +590,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -607,7 +607,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -624,7 +624,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -641,13 +641,13 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:37 GMT
 - request:
     method: get
@@ -711,7 +711,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "type" : "AVAILABILITY",
+            "metricDataType" : "AVAILABILITY",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -728,7 +728,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -745,7 +745,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -762,7 +762,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -779,7 +779,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -796,7 +796,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -813,7 +813,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -830,7 +830,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -847,7 +847,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -864,7 +864,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -881,7 +881,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -898,7 +898,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -915,7 +915,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -932,12 +932,12 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:37 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_list_metrics_for_WildFlys.yml
+++ b/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_list_metrics_for_WildFlys.yml
@@ -129,7 +129,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "metricDataType" : "AVAILABILITY",
+            "metricDataType" : "availability",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -146,7 +146,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -163,7 +163,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -180,7 +180,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -197,7 +197,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -214,7 +214,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -231,7 +231,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -248,7 +248,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -265,7 +265,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -282,7 +282,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -299,7 +299,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -316,7 +316,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -333,7 +333,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -350,7 +350,7 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },

--- a/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_list_metrics_for_WildFlys.yml
+++ b/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_list_metrics_for_WildFlys.yml
@@ -65,7 +65,7 @@ http_interactions:
           },
           "id" : "Local~~"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:37 GMT
 - request:
     method: get
@@ -129,7 +129,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "type" : "AVAILABILITY",
+            "metricDataType" : "AVAILABILITY",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -146,7 +146,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -163,7 +163,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -180,7 +180,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -197,7 +197,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -214,7 +214,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -231,7 +231,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -248,7 +248,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -265,7 +265,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -282,7 +282,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -299,7 +299,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -316,7 +316,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -333,7 +333,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -350,12 +350,12 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:37 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_list_metrics_of_given_metric_type.yml
+++ b/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_list_metrics_of_given_metric_type.yml
@@ -65,7 +65,6 @@ http_interactions:
             "unit" : "BYTES",
             "metricDataType" : "gauge",
             "collectionInterval" : 300,
-            "metricDataType" : "GAUGE",
             "id" : "Platform_File Store_Total Space"
           },
           "id" : "MI~R~[<%= feed_uuid %>/platform~/OPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem/FILE_STORE=/dev/mapper/fedora-root]~MT~Platform_File Store_Total Space"
@@ -84,11 +83,10 @@ http_interactions:
             "unit" : "BYTES",
             "metricDataType" : "gauge",
             "collectionInterval" : 300,
-            "metricDataType" : "GAUGE",
             "id" : "Platform_File Store_Total Space"
           },
           "id" : "MI~R~[<%= feed_uuid %>/platform~/OPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem/FILE_STORE=~]~MT~Platform_File Store_Total Space"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Tue, 27 Sep 2016 22:09:35 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_list_metrics_of_given_metric_type.yml
+++ b/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_list_metrics_of_given_metric_type.yml
@@ -65,7 +65,7 @@ http_interactions:
             "unit" : "BYTES",
             "metricDataType" : "gauge",
             "collectionInterval" : 300,
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "id" : "Platform_File Store_Total Space"
           },
           "id" : "MI~R~[<%= feed_uuid %>/platform~/OPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem/FILE_STORE=/dev/mapper/fedora-root]~MT~Platform_File Store_Total Space"
@@ -84,7 +84,7 @@ http_interactions:
             "unit" : "BYTES",
             "metricDataType" : "gauge",
             "collectionInterval" : 300,
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "id" : "Platform_File Store_Total Space"
           },
           "id" : "MI~R~[<%= feed_uuid %>/platform~/OPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem/FILE_STORE=~]~MT~Platform_File Store_Total Space"

--- a/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_list_metrics_of_given_resource_type.yml
+++ b/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_list_metrics_of_given_resource_type.yml
@@ -62,7 +62,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "type" : "AVAILABILITY",
+            "metricDataType" : "AVAILABILITY",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -79,7 +79,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -96,7 +96,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -113,7 +113,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -130,7 +130,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -147,7 +147,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -164,7 +164,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -181,7 +181,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -198,7 +198,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -215,7 +215,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -232,7 +232,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -249,7 +249,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -266,7 +266,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -283,12 +283,12 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:37 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_list_metrics_of_given_resource_type.yml
+++ b/spec/vcr_cassettes/Inventory/NonSecure/inventory_0_17/Templates/Should_list_metrics_of_given_resource_type.yml
@@ -62,7 +62,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "metricDataType" : "AVAILABILITY",
+            "metricDataType" : "availability",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -79,7 +79,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -96,7 +96,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -113,7 +113,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -130,7 +130,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -147,7 +147,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -164,7 +164,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -181,7 +181,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -198,7 +198,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -215,7 +215,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -232,7 +232,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -249,7 +249,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -266,7 +266,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -283,7 +283,7 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },

--- a/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_create_a_nested_resource_and_metric_on_it.yml
+++ b/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_create_a_nested_resource_and_metric_on_it.yml
@@ -54,7 +54,7 @@ http_interactions:
           "identityHash" : "68e7c253d97d52d5a4e412a0297567440ba5f5",
           "id" : "Secure_feed_may_exist"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:52 GMT
 - request:
     method: post
@@ -111,7 +111,7 @@ http_interactions:
           "identityHash" : "5c475fba1eab01a3f0fbabfbe0efac752aeb7",
           "id" : "rt-123-1"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:52 GMT
 - request:
     method: get
@@ -164,7 +164,7 @@ http_interactions:
           "identityHash" : "5c475fba1eab01a3f0fbabfbe0efac752aeb7",
           "id" : "rt-123-1"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:52 GMT
 - request:
     method: post
@@ -227,7 +227,7 @@ http_interactions:
           },
           "id" : "r124-a"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:52 GMT
 - request:
     method: post
@@ -290,14 +290,14 @@ http_interactions:
           },
           "id" : "r124-b"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:52 GMT
 - request:
     method: post
     uri: https://<%= super_secret_username %>:<%= super_secret_password %>@127.0.0.1:8443/hawkular/inventory/entity/f;Secure_feed_may_exist/metricType
     body:
       encoding: UTF-8
-      string: '{"id":"mt-124-a","type":"GAUGE","unit":"NONE","collectionInterval":60}'
+      string: '{"id":"mt-124-a","metricDataType":"gauge","unit":"NONE","collectionInterval":60}'
     headers:
       Accept:
       - application/json
@@ -345,11 +345,11 @@ http_interactions:
           "path" : "/t;hawkular/f;Secure_feed_may_exist/mt;mt-124-a",
           "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
           "unit" : "NONE",
-          "metricDataType" : "GAUGE",
+          "metricDataType" : "gauge",
           "collectionInterval" : 60,
           "id" : "mt-124-a"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:52 GMT
 - request:
     method: get
@@ -400,11 +400,11 @@ http_interactions:
           "path" : "/t;hawkular/f;Secure_feed_may_exist/mt;mt-124-a",
           "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
           "unit" : "NONE",
-          "metricDataType" : "GAUGE",
+          "metricDataType" : "gauge",
           "collectionInterval" : 60,
           "id" : "mt-124-a"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:52 GMT
 - request:
     method: post
@@ -463,13 +463,13 @@ http_interactions:
             "path" : "/t;hawkular/f;Secure_feed_may_exist/mt;mt-124-a",
             "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "mt-124-a"
           },
           "id" : "m-124-a"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:53 GMT
 - request:
     method: get
@@ -527,13 +527,13 @@ http_interactions:
             "path" : "/t;hawkular/f;Secure_feed_may_exist/mt;mt-124-a",
             "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "mt-124-a"
           },
           "id" : "m-124-a"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:53 GMT
 - request:
     method: post
@@ -590,7 +590,7 @@ http_interactions:
           "source" : "/t;hawkular/f;Secure_feed_may_exist/r;r124-a/r;r124-b",
           "target" : "/t;hawkular/f;Secure_feed_may_exist/m;m-124-a"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:53 GMT
 - request:
     method: get
@@ -653,12 +653,12 @@ http_interactions:
             "path" : "/t;hawkular/f;Secure_feed_may_exist/mt;mt-124-a",
             "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "mt-124-a"
           },
           "id" : "m-124-a"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:53 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_create_a_nested_resource_and_metric_on_it.yml
+++ b/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_create_a_nested_resource_and_metric_on_it.yml
@@ -345,7 +345,7 @@ http_interactions:
           "path" : "/t;hawkular/f;Secure_feed_may_exist/mt;mt-124-a",
           "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
           "unit" : "NONE",
-          "type" : "GAUGE",
+          "metricDataType" : "GAUGE",
           "collectionInterval" : 60,
           "id" : "mt-124-a"
         }
@@ -400,7 +400,7 @@ http_interactions:
           "path" : "/t;hawkular/f;Secure_feed_may_exist/mt;mt-124-a",
           "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
           "unit" : "NONE",
-          "type" : "GAUGE",
+          "metricDataType" : "GAUGE",
           "collectionInterval" : 60,
           "id" : "mt-124-a"
         }
@@ -463,7 +463,7 @@ http_interactions:
             "path" : "/t;hawkular/f;Secure_feed_may_exist/mt;mt-124-a",
             "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "mt-124-a"
           },
@@ -527,7 +527,7 @@ http_interactions:
             "path" : "/t;hawkular/f;Secure_feed_may_exist/mt;mt-124-a",
             "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "mt-124-a"
           },
@@ -653,7 +653,7 @@ http_interactions:
             "path" : "/t;hawkular/f;Secure_feed_may_exist/mt;mt-124-a",
             "identityHash" : "b06c658d2341eedf26fcff6667bcf3b2556c994",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "mt-124-a"
           },

--- a/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_create_a_resource_with_metric.yml
+++ b/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_create_a_resource_with_metric.yml
@@ -410,7 +410,7 @@ http_interactions:
           "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
           "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
           "unit" : "NONE",
-          "type" : "GAUGE",
+          "metricDataType" : "GAUGE",
           "collectionInterval" : 60,
           "id" : "mt-124"
         }
@@ -465,7 +465,7 @@ http_interactions:
           "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
           "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
           "unit" : "NONE",
-          "type" : "GAUGE",
+          "metricDataType" : "GAUGE",
           "collectionInterval" : 60,
           "id" : "mt-124"
         }
@@ -528,7 +528,7 @@ http_interactions:
             "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
             "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "mt-124"
           },
@@ -592,7 +592,7 @@ http_interactions:
             "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
             "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "mt-124"
           },
@@ -714,7 +714,7 @@ http_interactions:
             "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
             "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "mt-124"
           },
@@ -778,7 +778,7 @@ http_interactions:
             "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
             "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "mt-124"
           },

--- a/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_create_a_resource_with_metric.yml
+++ b/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_create_a_resource_with_metric.yml
@@ -65,7 +65,7 @@ http_interactions:
             } ] ]
           }
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:51 GMT
 - request:
     method: get
@@ -120,7 +120,7 @@ http_interactions:
           "identityHash" : "74c06ecbd9cadebfda6338c1333995f6cc55b",
           "id" : "feed_may_exist"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:51 GMT
 - request:
     method: post
@@ -173,7 +173,7 @@ http_interactions:
           "errorMsg" : "Entity with id 'null' already exists at some of the positions: null",
           "details" : { }
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:51 GMT
 - request:
     method: get
@@ -226,7 +226,7 @@ http_interactions:
           "identityHash" : "30a52c53a93cb102e499367ecc55ed8a03b0b1",
           "id" : "rt-123"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:51 GMT
 - request:
     method: post
@@ -292,7 +292,7 @@ http_interactions:
           },
           "id" : "r124"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:51 GMT
 - request:
     method: get
@@ -355,14 +355,14 @@ http_interactions:
           },
           "id" : "r124"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:51 GMT
 - request:
     method: post
     uri: https://<%= super_secret_username %>:<%= super_secret_password %>@127.0.0.1:8443/hawkular/inventory/entity/f;feed_may_exist/metricType
     body:
       encoding: UTF-8
-      string: '{"id":"mt-124","type":"GAUGE","unit":"NONE","collectionInterval":60}'
+      string: '{"id":"mt-124","metricDataType":"gauge","unit":"NONE","collectionInterval":60}'
     headers:
       Accept:
       - application/json
@@ -410,11 +410,11 @@ http_interactions:
           "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
           "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
           "unit" : "NONE",
-          "metricDataType" : "GAUGE",
+          "metricDataType" : "gauge",
           "collectionInterval" : 60,
           "id" : "mt-124"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:51 GMT
 - request:
     method: get
@@ -465,11 +465,11 @@ http_interactions:
           "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
           "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
           "unit" : "NONE",
-          "metricDataType" : "GAUGE",
+          "metricDataType" : "gauge",
           "collectionInterval" : 60,
           "id" : "mt-124"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:51 GMT
 - request:
     method: post
@@ -528,13 +528,13 @@ http_interactions:
             "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
             "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "mt-124"
           },
           "id" : "m-124"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:51 GMT
 - request:
     method: get
@@ -592,13 +592,13 @@ http_interactions:
             "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
             "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "mt-124"
           },
           "id" : "m-124"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:51 GMT
 - request:
     method: post
@@ -655,7 +655,7 @@ http_interactions:
           "source" : "/t;hawkular/f;feed_may_exist/r;r124",
           "target" : "/t;hawkular/f;feed_may_exist/m;m-124"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:51 GMT
 - request:
     method: post
@@ -714,13 +714,13 @@ http_interactions:
             "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
             "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "mt-124"
           },
           "id" : "m-124-1"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:52 GMT
 - request:
     method: get
@@ -778,13 +778,13 @@ http_interactions:
             "path" : "/t;hawkular/f;feed_may_exist/mt;mt-124",
             "identityHash" : "dabc11fbfd76774e47c38f91ea832d404cc0df",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "mt-124"
           },
           "id" : "m-124-1"
         }
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:52 GMT
 - request:
     method: post
@@ -841,6 +841,6 @@ http_interactions:
           "source" : "/t;hawkular/f;feed_may_exist/r;r124",
           "target" : "/t;hawkular/f;feed_may_exist/m;m-124-1"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:52 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_have_the_same_requested_metric_type_id.yml
+++ b/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_have_the_same_requested_metric_type_id.yml
@@ -62,7 +62,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "type" : "AVAILABILITY",
+            "metricDataType" : "AVAILABILITY",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },

--- a/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_have_the_same_requested_metric_type_id.yml
+++ b/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_have_the_same_requested_metric_type_id.yml
@@ -62,12 +62,12 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "metricDataType" : "AVAILABILITY",
+            "metricDataType" : "availability",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
           "id" : "AI~R~[<%= feed_uuid %>/Local~~]~AT~Server Availability~Server Availability"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:50 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_list_heap_metrics_for_WildFlys.yml
+++ b/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_list_heap_metrics_for_WildFlys.yml
@@ -65,7 +65,7 @@ http_interactions:
           },
           "id" : "Local~~"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:49 GMT
 - request:
     method: get
@@ -129,7 +129,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "metricDataType" : "AVAILABILITY",
+            "metricDataType" : "availability",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -146,7 +146,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -163,7 +163,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -180,7 +180,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -197,7 +197,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -214,7 +214,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -231,7 +231,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -248,7 +248,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -265,7 +265,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -282,7 +282,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -299,7 +299,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -316,7 +316,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -333,7 +333,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -350,13 +350,13 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:49 GMT
 - request:
     method: get
@@ -420,7 +420,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "metricDataType" : "AVAILABILITY",
+            "metricDataType" : "availability",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -437,7 +437,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -454,7 +454,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -471,7 +471,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -488,7 +488,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -505,7 +505,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -522,7 +522,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -539,7 +539,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -556,7 +556,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -573,7 +573,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -590,7 +590,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -607,7 +607,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -624,7 +624,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -641,13 +641,13 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:49 GMT
 - request:
     method: get
@@ -711,7 +711,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "metricDataType" : "AVAILABILITY",
+            "metricDataType" : "availability",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -728,7 +728,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -745,7 +745,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -762,7 +762,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -779,7 +779,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -796,7 +796,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -813,7 +813,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -830,7 +830,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -847,7 +847,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -864,7 +864,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -881,7 +881,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -898,7 +898,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -915,7 +915,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -932,12 +932,12 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_list_heap_metrics_for_WildFlys.yml
+++ b/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_list_heap_metrics_for_WildFlys.yml
@@ -129,7 +129,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "type" : "AVAILABILITY",
+            "metricDataType" : "AVAILABILITY",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -146,7 +146,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -163,7 +163,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -180,7 +180,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -197,7 +197,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -214,7 +214,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -231,7 +231,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -248,7 +248,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -265,7 +265,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -282,7 +282,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -299,7 +299,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -316,7 +316,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -333,7 +333,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -350,7 +350,7 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },
@@ -420,7 +420,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "type" : "AVAILABILITY",
+            "metricDataType" : "AVAILABILITY",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -437,7 +437,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -454,7 +454,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -471,7 +471,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -488,7 +488,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -505,7 +505,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -522,7 +522,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -539,7 +539,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -556,7 +556,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -573,7 +573,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -590,7 +590,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -607,7 +607,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -624,7 +624,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -641,7 +641,7 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },
@@ -711,7 +711,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "type" : "AVAILABILITY",
+            "metricDataType" : "AVAILABILITY",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -728,7 +728,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -745,7 +745,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -762,7 +762,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -779,7 +779,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -796,7 +796,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -813,7 +813,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -830,7 +830,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -847,7 +847,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -864,7 +864,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -881,7 +881,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -898,7 +898,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -915,7 +915,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -932,7 +932,7 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },

--- a/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_list_metrics_for_WildFlys.yml
+++ b/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_list_metrics_for_WildFlys.yml
@@ -65,7 +65,7 @@ http_interactions:
           },
           "id" : "Local~~"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:49 GMT
 - request:
     method: get
@@ -129,7 +129,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "metricDataType" : "AVAILABILITY",
+            "metricDataType" : "availability",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -146,7 +146,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -163,7 +163,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -180,7 +180,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -197,7 +197,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -214,7 +214,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -231,7 +231,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -248,7 +248,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -265,7 +265,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -282,7 +282,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -299,7 +299,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -316,7 +316,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -333,7 +333,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -350,12 +350,12 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_list_metrics_for_WildFlys.yml
+++ b/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_list_metrics_for_WildFlys.yml
@@ -129,7 +129,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "type" : "AVAILABILITY",
+            "metricDataType" : "AVAILABILITY",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -146,7 +146,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -163,7 +163,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -180,7 +180,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -197,7 +197,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -214,7 +214,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -231,7 +231,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -248,7 +248,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -265,7 +265,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -282,7 +282,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -299,7 +299,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -316,7 +316,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -333,7 +333,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -350,7 +350,7 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },

--- a/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_list_metrics_of_given_metric_type.yml
+++ b/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_list_metrics_of_given_metric_type.yml
@@ -62,7 +62,7 @@ http_interactions:
             "name" : "Total Space",
             "identityHash" : "4753b6bbe4fad4dfd57fae8fc2d35f91af13e53",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 300,
             "id" : "Total Space"
           },
@@ -79,12 +79,12 @@ http_interactions:
             "name" : "Total Space",
             "identityHash" : "4753b6bbe4fad4dfd57fae8fc2d35f91af13e53",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 300,
             "id" : "Total Space"
           },
           "id" : "MI~R~[<%= feed_uuid %>/platform~/OPERATING_SYSTEM=<%= feed_uuid %>_OperatingSystem/FILE_STORE=tmpfs]~MT~Total Space"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_list_metrics_of_given_metric_type.yml
+++ b/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_list_metrics_of_given_metric_type.yml
@@ -62,7 +62,7 @@ http_interactions:
             "name" : "Total Space",
             "identityHash" : "4753b6bbe4fad4dfd57fae8fc2d35f91af13e53",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 300,
             "id" : "Total Space"
           },
@@ -79,7 +79,7 @@ http_interactions:
             "name" : "Total Space",
             "identityHash" : "4753b6bbe4fad4dfd57fae8fc2d35f91af13e53",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 300,
             "id" : "Total Space"
           },

--- a/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_list_metrics_of_given_resource_type.yml
+++ b/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_list_metrics_of_given_resource_type.yml
@@ -62,7 +62,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "metricDataType" : "AVAILABILITY",
+            "metricDataType" : "availability",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -79,7 +79,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -96,7 +96,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -113,7 +113,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -130,7 +130,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -147,7 +147,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -164,7 +164,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -181,7 +181,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "metricDataType" : "COUNTER",
+            "metricDataType" : "counter",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -198,7 +198,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -215,7 +215,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -232,7 +232,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -249,7 +249,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -266,7 +266,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -283,12 +283,12 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "metricDataType" : "GAUGE",
+            "metricDataType" : "gauge",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },
           "id" : "MI~R~[<%= feed_uuid %>/Local~~]~MT~WildFly Threading Metrics~Thread Count"
         } ]
-    http_version: 
+    http_version:
   recorded_at: Wed, 10 Aug 2016 22:35:49 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_list_metrics_of_given_resource_type.yml
+++ b/spec/vcr_cassettes/Inventory/Secure/inventory_0_17/Templates/Should_list_metrics_of_given_resource_type.yml
@@ -62,7 +62,7 @@ http_interactions:
             "name" : "Server Availability",
             "identityHash" : "69beedc2b0c5cf2f3d0484b9c1aa9e4cdcf93",
             "unit" : "NONE",
-            "type" : "AVAILABILITY",
+            "metricDataType" : "AVAILABILITY",
             "collectionInterval" : 30,
             "id" : "Server Availability~Server Availability"
           },
@@ -79,7 +79,7 @@ http_interactions:
             "name" : "Aggregated Active Web Sessions",
             "identityHash" : "a82dc495957628db4b96ca5c44213ce023c792b9",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Active Web Sessions"
           },
@@ -96,7 +96,7 @@ http_interactions:
             "name" : "Aggregated Expired Web Sessions",
             "identityHash" : "3c806e8b625362b37f972a3594448c4aa8b3",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions"
           },
@@ -113,7 +113,7 @@ http_interactions:
             "name" : "Aggregated Max Active Web Sessions",
             "identityHash" : "a677b62ab5ec7632a32af8b6ef08aef813fd1f",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Max Active Web Sessions"
           },
@@ -130,7 +130,7 @@ http_interactions:
             "name" : "Aggregated Rejected Web Sessions",
             "identityHash" : "6af37a7acb8c6eab4818313a281748152896534",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions"
           },
@@ -147,7 +147,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Count",
             "identityHash" : "95556b3b6367d481ebfd12997646e08fef9291e0",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Count"
           },
@@ -164,7 +164,7 @@ http_interactions:
             "name" : "Aggregated Servlet Request Time",
             "identityHash" : "f949025e0087974acae8cffab1598344932f6c",
             "unit" : "NONE",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Aggregated Web Metrics~Aggregated Servlet Request Time"
           },
@@ -181,7 +181,7 @@ http_interactions:
             "name" : "Accumulated GC Duration",
             "identityHash" : "44916cf1eae6344af4cd0b2a562c5328562c3",
             "unit" : "MILLISECONDS",
-            "type" : "COUNTER",
+            "metricDataType" : "COUNTER",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Accumulated GC Duration"
           },
@@ -198,7 +198,7 @@ http_interactions:
             "name" : "Heap Committed",
             "identityHash" : "405253f87a6e98aabe2d7a4a524f5796d9d97e",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Committed"
           },
@@ -215,7 +215,7 @@ http_interactions:
             "name" : "Heap Max",
             "identityHash" : "a84cf574232510897e26b98fd9ea5702a95dfc7",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~Heap Max"
           },
@@ -232,7 +232,7 @@ http_interactions:
             "name" : "Heap Used",
             "identityHash" : "3be5b5fdabed925ac46fdc6d8295e34bbd3147a",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~Heap Used"
           },
@@ -249,7 +249,7 @@ http_interactions:
             "name" : "NonHeap Committed",
             "identityHash" : "55d9f8e5b0a3b5d0af3fd3bac67b08b186c68b5",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 60,
             "id" : "WildFly Memory Metrics~NonHeap Committed"
           },
@@ -266,7 +266,7 @@ http_interactions:
             "name" : "NonHeap Used",
             "identityHash" : "c785eddfb0f0baa1e832fc38485d686e2297497",
             "unit" : "BYTES",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 30,
             "id" : "WildFly Memory Metrics~NonHeap Used"
           },
@@ -283,7 +283,7 @@ http_interactions:
             "name" : "Thread Count",
             "identityHash" : "1e41cf1c2b3c07e23983a3789c91bdc6f1cc88",
             "unit" : "NONE",
-            "type" : "GAUGE",
+            "metricDataType" : "GAUGE",
             "collectionInterval" : 120,
             "id" : "WildFly Threading Metrics~Thread Count"
           },


### PR DESCRIPTION
Metric type field is now named "metricDataType".
This change has been live for a while, see https://github.com/hawkular/hawkular-inventory/pull/283 (0.18.0.Final). Previous naming still works as deprecated but might be removed soon