### PR TITLE
Making sure we compare 2 strings and not symbol with string.

### DIFF
--- a/hawkularclient.gemspec
+++ b/hawkularclient.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rubocop', '= 0.34.2')
   gem.add_development_dependency('coveralls')
   gem.add_development_dependency('rack', '~> 1.6.4')
+  gem.add_development_dependency('pry-byebug')
 
   gem.rdoc_options << '--title' << gem.name <<
     '--main' << 'README.rdoc' << '--line-numbers' << '--inline-source'

--- a/lib/hawkular/operations/operations_api.rb
+++ b/lib/hawkular/operations/operations_api.rb
@@ -338,7 +338,8 @@ module Hawkular::Operations
         when "#{operation_name}Response"
           same_path = parsed[:data]['resourcePath'] == operation_payload[:resourcePath]
           # failed operations don't return the operation name from some strange reason
-          same_name = parsed[:data]['operationName'] == operation_payload[:operationName]
+          same_name = operation_payload[:operationName].nil? ||
+                      parsed[:data]['operationName'] == operation_payload[:operationName].to_s
           if same_path # using the resource path as a correlation id
             success = same_name && parsed[:data]['status'] == 'OK'
             success ? callback.perform(:success, parsed[:data]) : callback.perform(:failure, parsed[:data]['message'])


### PR DESCRIPTION
This PR fixes this issue: https://bugzilla.redhat.com/show_bug.cgi?id=1391694#c5

If the operation is called like [this](https://github.com/ManageIQ/manageiq/blob/67f80275ef8224626dfb65f8496c0b62f2bcb3a0/app/models/manageiq/providers/hawkular/middleware_manager.rb#L171) (the operation name is given by a symbol and not as a string), it is performed correctly, but the error call back is called.