### PR TITLE
Fixes dependency requeriment for test suite on Ruby 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,3 @@ services:
   - docker
 before_install:
   - (test $RUN_ON_LIVE_SERVER = 1 && ./.travis/start_hawkular_services.sh -d && ./.travis/wait_for_services.rb) || echo "Skipping live server"
-# Lets wait a bit for the agent to load everything it needs.
-before_script:
-  - (test $RUN_ON_LIVE_SERVER = 1 && sleep 20s) || true

--- a/.travis/wait_for_services.rb
+++ b/.travis/wait_for_services.rb
@@ -34,3 +34,6 @@ services.each do |name, service|
     sleep 5
   end
 end
+puts 'Waiting 2 minutes for agent to complete it\'s first round...'
+sleep 120
+puts 'Hawkular-services started successfully... '

--- a/hawkularclient.gemspec
+++ b/hawkularclient.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('addressable')
   gem.add_development_dependency('shoulda')
   gem.add_development_dependency('rspec-rails', '~> 3.1')
+  gem.add_development_dependency('actionpack',  '~> 4')
   gem.add_development_dependency('rake', '< 11')
   gem.add_development_dependency('simple-websocket-vcr', '= 0.0.7')
   gem.add_development_dependency('yard')


### PR DESCRIPTION
Locked action-pack dependency on latest 4.
When testing on a live server, increases wait time from 20s to 120s to wait for the hawkular wildfly agent.