### PR TITLE
Officially pass through options to RestClient

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -61,6 +61,18 @@ You can also access each subproject's API individually, if you would like to use
     options: { tenant: 'hawkular' }
   )
 
+=== HTTP and HTTPS options
+
+Will all client classes, the +:options+ hash can contain extra parameters passed through to +RestClient+ gem.  It can include a +:headers+ sub-hash to add custom headers:
+
+  require 'hawkular/hawkular_client'
+  client = Hawkular::Client.new(
+    entrypoint: 'http://localhost:8080',
+    credentials: { username: 'jdoe', password: 'password' },
+    options: { tenant: 'hawkular', proxy: 'proxy.example.com', ssl_ca_file: 'ca.pem',
+               headers: {'Max-Forwards': 5} }
+  )
+
 === Examples
 
 Suppose you will monitor the availability of two networks to later determine which one is the best.
@@ -147,4 +159,3 @@ variables:
 Client documentation can be generated using http://yardoc.org
 
     yardoc
-


### PR DESCRIPTION
[Current code][1] looks like it's building new `options` hash for RestClient from `@options` but `options` is not a local var, it's actually an attr_reader for `@options`.
The result is that all options are passed through to RestClient, including unrelated keys like `:tenant`.
Apparently RestClient doesn't mind getting options it doesn't understand, but let's not do that.

I propose here to make it official and documented that you can pass any RestClient options.
There are good reasons to expose most of them (proxy and ssl_* are good examples), it's easier on users to use already known names from RestClient than each gem inventing subtly different ones, and simple pass-through is easier to maintain than adding them one by one.
I've kept `:http_proxy_uri` support for backward compatibility, but RestClient's `:proxy` becomes the recommended.
(I also documented how to pass custom headers, though use cases are harder to think of.  I believe that part already worked.)

The only slight incompatibility is that `.options` accessor on client objects will now return hashes with less entries.
[BTW given that you marked it `@!visibility private`, perhaps simply drop this accessor and use `@options` internally?  I also suspect `attr_reader :tenants` in `BaseClient` is unused?]

[1]: https://github.com/hawkular/hawkular-client-ruby/blob/02041e319eabc6851d0a5adf2319af3b83643ad9/lib/hawkular/base_client.rb#L75-L87