### PR TITLE
update tests to be compatible with latest h-alerts (1.5.1) in h-services

### DIFF
--- a/spec/integration/alerts_spec.rb
+++ b/spec/integration/alerts_spec.rb
@@ -192,7 +192,7 @@ module Hawkular::Alerts::RSpec
 
       ret = @client.get_action_definition 'email'
       expect(ret.size).to be(1)
-      expect(ret['email'].size).to be(7)
+      expect(ret['email'].size).to be(8)
 
       expect { @client.get_action_definition '-does-not-exist-' }
         .to raise_error(Hawkular::BaseClient::HawkularException)

--- a/spec/integration/operations_spec.rb
+++ b/spec/integration/operations_spec.rb
@@ -190,14 +190,14 @@ module Hawkular::Operations::RSpec
 
         it 'Restart should be performed and eventually respond with success' do
           wf_server_resource_id = 'Local~~'
-          alerts_war_resource_id = 'Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war'
+          status_war_resource_id = 'Local~%2Fdeployment%3Dhawkular-status.war'
           path = CanonicalPath.new(tenant_id: @tenant_id,
                                    feed_id: @feed_id,
-                                   resource_ids: [wf_server_resource_id, alerts_war_resource_id])
+                                   resource_ids: [wf_server_resource_id, status_war_resource_id])
 
           restart = {
             resource_path: path.to_s,
-            deployment_name: 'hawkular-alerts-actions-email.war'
+            deployment_name: 'hawkular-status.war'
           }
 
           actual_data = {}
@@ -244,14 +244,14 @@ module Hawkular::Operations::RSpec
 
         it 'Disable should be performed and eventually respond with success' do
           wf_server_resource_id = 'Local~~'
-          alerts_war_resource_id = 'Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war'
+          status_war_resource_id = 'Local~%2Fdeployment%3Dhawkular-status.war'
           path = CanonicalPath.new(tenant_id: @tenant_id,
                                    feed_id: @feed_id,
-                                   resource_ids: [wf_server_resource_id, alerts_war_resource_id])
+                                   resource_ids: [wf_server_resource_id, status_war_resource_id])
 
           disable = {
             resource_path: path.to_s,
-            deployment_name: 'hawkular-alerts-actions-email.war'
+            deployment_name: 'hawkular-status.war'
           }
           actual_data = {}
           client.disable_deployment(disable) do |on|
@@ -371,18 +371,18 @@ module Hawkular::Operations::RSpec
 
         it 'Restart can be run multiple times in parallel' do
           wf_server_resource_id = 'Local~~'
-          alerts_war_resource_id = 'Local~%2Fdeployment%3Dhawkular-alerts-actions-email.war'
+          status_war_resource_id = 'Local~%2Fdeployment%3Dhawkular-status.war'
           console_war_resource_id = 'Local~%2Fdeployment%3Dhawkular-wildfly-agent-download.war'
           path1 = CanonicalPath.new(tenant_id: @tenant_id,
                                     feed_id: @feed_id,
-                                    resource_ids: [wf_server_resource_id, alerts_war_resource_id])
+                                    resource_ids: [wf_server_resource_id, status_war_resource_id])
           path2 = CanonicalPath.new(tenant_id: @tenant_id,
                                     feed_id: @feed_id,
                                     resource_ids: [wf_server_resource_id, console_war_resource_id])
 
           restart1 = {
             resource_path: path1.to_s,
-            deployment_name: 'hawkular-alerts-actions-email.war'
+            deployment_name: 'hawkular-status.war'
           }
 
           restart2 = {

--- a/spec/vcr_cassettes/Alert/Triggers/Templates/Should_get_the_action_definitions.yml
+++ b/spec/vcr_cassettes/Alert/Triggers/Templates/Should_get_the_action_definitions.yml
@@ -17,8 +17,6 @@ http_interactions:
       - hawkular
       Content-Type:
       - application/json
-      Host:
-      - localhost:8080
   response:
     status:
       code: 200
@@ -35,18 +33,18 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 27 Sep 2016 18:17:14 GMT
+      - Wed, 01 Feb 2017 22:44:58 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '9'
+      - '19'
     body:
       encoding: UTF-8
-      string: '["email"]'
+      string: '["email","webhook"]'
     http_version: 
-  recorded_at: Tue, 27 Sep 2016 18:17:14 GMT
+  recorded_at: Wed, 01 Feb 2017 22:44:58 GMT
 - request:
     method: get
     uri: http://<%= username %>:<%= password %>@localhost:8080/hawkular/alerts/plugins/email
@@ -64,8 +62,6 @@ http_interactions:
       - hawkular
       Content-Type:
       - application/json
-      Host:
-      - localhost:8080
   response:
     status:
       code: 200
@@ -82,18 +78,63 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 27 Sep 2016 18:17:14 GMT
+      - Wed, 01 Feb 2017 22:44:58 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '87'
+      - '94'
     body:
       encoding: UTF-8
-      string: '["cc","from","from-name","template.hawkular.url","template.html","template.plain","to"]'
+      string: '["cc","from","from-name","mail","template.hawkular.url","template.html","template.plain","to"]'
     http_version: 
-  recorded_at: Tue, 27 Sep 2016 18:17:14 GMT
+  recorded_at: Wed, 01 Feb 2017 22:44:58 GMT
+- request:
+    method: get
+    uri: http://<%= username %>:<%= password %>@localhost:8080/hawkular/alerts/plugins/webhook
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Hawkular-Tenant:
+      - hawkular
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Wed, 01 Feb 2017 22:44:58 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '26'
+    body:
+      encoding: UTF-8
+      string: '["method","timeout","url"]'
+    http_version: 
+  recorded_at: Wed, 01 Feb 2017 22:44:58 GMT
 - request:
     method: get
     uri: http://<%= username %>:<%= password %>@localhost:8080/hawkular/alerts/plugins/email
@@ -111,8 +152,6 @@ http_interactions:
       - hawkular
       Content-Type:
       - application/json
-      Host:
-      - localhost:8080
   response:
     status:
       code: 200
@@ -129,18 +168,18 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 27 Sep 2016 18:17:15 GMT
+      - Wed, 01 Feb 2017 22:44:58 GMT
       Connection:
       - keep-alive
       Content-Type:
       - application/json
       Content-Length:
-      - '87'
+      - '94'
     body:
       encoding: UTF-8
-      string: '["cc","from","from-name","template.hawkular.url","template.html","template.plain","to"]'
+      string: '["cc","from","from-name","mail","template.hawkular.url","template.html","template.plain","to"]'
     http_version: 
-  recorded_at: Tue, 27 Sep 2016 18:17:15 GMT
+  recorded_at: Wed, 01 Feb 2017 22:44:58 GMT
 - request:
     method: get
     uri: http://<%= username %>:<%= password %>@localhost:8080/hawkular/alerts/plugins/-does-not-exist-
@@ -158,8 +197,6 @@ http_interactions:
       - hawkular
       Content-Type:
       - application/json
-      Host:
-      - localhost:8080
   response:
     status:
       code: 404
@@ -176,7 +213,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Tue, 27 Sep 2016 18:17:15 GMT
+      - Wed, 01 Feb 2017 22:44:58 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -187,5 +224,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"errorMsg":"actionPlugin: -does-not-exist- not found"}'
     http_version: 
-  recorded_at: Tue, 27 Sep 2016 18:17:15 GMT
+  recorded_at: Wed, 01 Feb 2017 22:44:58 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Operation/NonSecure/Operation/Disable_should_be_performed_and_eventually_respond_with_success.json
+++ b/spec/vcr_cassettes/Operation/NonSecure/Operation/Disable_should_be_performed_and_eventually_respond_with_success.json
@@ -3,21 +3,21 @@
     {
       "operation": "read",
       "type": "text",
-      "data": "WelcomeResponse={\"sessionId\":\"jXweY_aXtTBt3i_9HfzShEFKgp0PGDCQzpAiWAKb\"}"
+      "data": "WelcomeResponse={\"sessionId\":\"7U-i_UFx9DgRDK53vk_Z9A_XXAXHJDkFEaOG0Y3I\"}"
     },
     {
       "operation": "write",
-      "data": "DisableApplicationRequest={\"resourcePath\":\"/t;<%= tenant_id %>/f;<%= feed_id %>/r;Local~~\",\"destinationFileName\":\"<%= tenant_id %>-alerts-actions-email.war\",\"authentication\":{\"username\":\"jdoe\",\"password\":\"password\"}}"
+      "data": "DisableApplicationRequest={\"resourcePath\":\"/t;<%= tenant_id %>/f;<%= feed_id %>/r;Local~~\",\"destinationFileName\":\"<%= tenant_id %>-status.war\",\"authentication\":{\"username\":\"jdoe\",\"password\":\"password\"}}"
     },
     {
       "operation": "read",
       "type": "text",
-      "data": "GenericSuccessResponse={\"message\":\"The request has been forwarded to feed [<%= feed_id %>] (MessageId=ID:25bd5c9e-6637-11e6-a149-05583a5efefa)\"}"
+      "data": "GenericSuccessResponse={\"message\":\"The request has been forwarded to feed [<%= feed_id %>] (MessageId=ID:853e68db-e8d0-11e6-a6d2-4b35aefc3b69)\"}"
     },
     {
       "operation": "read",
       "type": "text",
-      "data": "DisableApplicationResponse={\"destinationFileName\":\"<%= tenant_id %>-alerts-actions-email.war\",\"resourcePath\":\"/t;<%= tenant_id %>/f;<%= feed_id %>/r;Local~~\",\"destinationSessionId\":\"jXweY_aXtTBt3i_9HfzShEFKgp0PGDCQzpAiWAKb\",\"status\":\"OK\",\"message\":\"Performed [Disable Deployment] on a [Application] given by Inventory path [/t;<%= tenant_id %>/f;<%= feed_id %>/r;Local~~]\"}"
+      "data": "DisableApplicationResponse={\"destinationFileName\":\"<%= tenant_id %>-status.war\",\"resourcePath\":\"/t;<%= tenant_id %>/f;<%= feed_id %>/r;Local~~\",\"destinationSessionId\":\"7U-i_UFx9DgRDK53vk_Z9A_XXAXHJDkFEaOG0Y3I\",\"status\":\"OK\",\"message\":\"Performed [Disable Deployment] on a [Application] given by Inventory path [/t;<%= tenant_id %>/f;<%= feed_id %>/r;Local~~]\"}"
     }
   ]
 ]

--- a/spec/vcr_cassettes/Operation/NonSecure/Operation/Restart_can_be_run_multiple_times_in_parallel.json
+++ b/spec/vcr_cassettes/Operation/NonSecure/Operation/Restart_can_be_run_multiple_times_in_parallel.json
@@ -3,11 +3,11 @@
     {
       "operation": "read",
       "type": "text",
-      "data": "WelcomeResponse={\"sessionId\":\"tOfR0vTFHOzChZqRvUpJKfN3iclEuma3SfZqXC_S\"}"
+      "data": "WelcomeResponse={\"sessionId\":\"3P3wpqaUgAp32EhbrYRy-AyfmjqWZSZfeS6Nc_Ez\"}"
     },
     {
       "operation": "write",
-      "data": "RestartApplicationRequest={\"resourcePath\":\"/t;<%= tenant_id %>/f;<%= feed_id %>/r;Local~~\",\"destinationFileName\":\"<%= tenant_id %>-alerts-actions-email.war\",\"authentication\":{\"username\":\"jdoe\",\"password\":\"password\"}}"
+      "data": "RestartApplicationRequest={\"resourcePath\":\"/t;<%= tenant_id %>/f;<%= feed_id %>/r;Local~~\",\"destinationFileName\":\"<%= tenant_id %>-status.war\",\"authentication\":{\"username\":\"jdoe\",\"password\":\"password\"}}"
     },
     {
       "operation": "write",
@@ -16,17 +16,17 @@
     {
       "operation": "read",
       "type": "text",
-      "data": "GenericSuccessResponse={\"message\":\"The request has been forwarded to feed [<%= feed_id %>] (MessageId=ID:29da5e11-6637-11e6-a149-05583a5efefa)\"}"
+      "data": "GenericSuccessResponse={\"message\":\"The request has been forwarded to feed [<%= feed_id %>] (MessageId=ID:8be2b1bb-e8d0-11e6-a6d2-4b35aefc3b69)\"}"
     },
     {
       "operation": "read",
       "type": "text",
-      "data": "GenericSuccessResponse={\"message\":\"The request has been forwarded to feed [<%= feed_id %>] (MessageId=ID:29dcf627-6637-11e6-a149-05583a5efefa)\"}"
+      "data": "GenericSuccessResponse={\"message\":\"The request has been forwarded to feed [<%= feed_id %>] (MessageId=ID:8be570e1-e8d0-11e6-a6d2-4b35aefc3b69)\"}"
     },
     {
       "operation": "read",
       "type": "text",
-      "data": "RestartApplicationResponse={\"destinationFileName\":\"<%= tenant_id %>-alerts-actions-email.war\",\"resourcePath\":\"/t;<%= tenant_id %>/f;<%= feed_id %>/r;Local~~\",\"destinationSessionId\":\"tOfR0vTFHOzChZqRvUpJKfN3iclEuma3SfZqXC_S\",\"status\":\"OK\",\"message\":\"Performed [Restart Deployment] on a [Application] given by Inventory path [/t;<%= tenant_id %>/f;<%= feed_id %>/r;Local~~]\"}"
+      "data": "RestartApplicationResponse={\"destinationFileName\":\"<%= tenant_id %>-status.war\",\"resourcePath\":\"/t;<%= tenant_id %>/f;<%= feed_id %>/r;Local~~\",\"destinationSessionId\":\"3P3wpqaUgAp32EhbrYRy-AyfmjqWZSZfeS6Nc_Ez\",\"status\":\"OK\",\"message\":\"Performed [Restart Deployment] on a [Application] given by Inventory path [/t;<%= tenant_id %>/f;<%= feed_id %>/r;Local~~]\"}"
     }
   ]
 ]

--- a/spec/vcr_cassettes/Operation/NonSecure/Operation/Restart_should_be_performed_and_eventually_respond_with_success.json
+++ b/spec/vcr_cassettes/Operation/NonSecure/Operation/Restart_should_be_performed_and_eventually_respond_with_success.json
@@ -3,21 +3,21 @@
     {
       "operation": "read",
       "type": "text",
-      "data": "WelcomeResponse={\"sessionId\":\"7gt_ULq42AEj8Sae8JL7emm6McpZek0o0FSjvnk7\"}"
+      "data": "WelcomeResponse={\"sessionId\":\"m_E2HZzEWyWyR6Y0zHGUKpMDouJziaKPWRlLOVm4\"}"
     },
     {
       "operation": "write",
-      "data": "RestartApplicationRequest={\"resourcePath\":\"/t;<%= tenant_id %>/f;<%= feed_id %>/r;Local~~\",\"destinationFileName\":\"<%= tenant_id %>-alerts-actions-email.war\",\"authentication\":{\"username\":\"jdoe\",\"password\":\"password\"}}"
+      "data": "RestartApplicationRequest={\"resourcePath\":\"/t;<%= tenant_id %>/f;<%= feed_id %>/r;Local~~\",\"destinationFileName\":\"<%= tenant_id %>-status.war\",\"authentication\":{\"username\":\"jdoe\",\"password\":\"password\"}}"
     },
     {
       "operation": "read",
       "type": "text",
-      "data": "GenericSuccessResponse={\"message\":\"The request has been forwarded to feed [<%= feed_id %>] (MessageId=ID:2129551e-6637-11e6-a149-05583a5efefa)\"}"
+      "data": "GenericSuccessResponse={\"message\":\"The request has been forwarded to feed [<%= feed_id %>] (MessageId=ID:81a0a8c0-e8d0-11e6-a6d2-4b35aefc3b69)\"}"
     },
     {
       "operation": "read",
       "type": "text",
-      "data": "RestartApplicationResponse={\"destinationFileName\":\"<%= tenant_id %>-alerts-actions-email.war\",\"resourcePath\":\"/t;<%= tenant_id %>/f;<%= feed_id %>/r;Local~~\",\"destinationSessionId\":\"7gt_ULq42AEj8Sae8JL7emm6McpZek0o0FSjvnk7\",\"status\":\"OK\",\"message\":\"Performed [Restart Deployment] on a [Application] given by Inventory path [/t;<%= tenant_id %>/f;<%= feed_id %>/r;Local~~]\"}"
+      "data": "RestartApplicationResponse={\"destinationFileName\":\"<%= tenant_id %>-status.war\",\"resourcePath\":\"/t;<%= tenant_id %>/f;<%= feed_id %>/r;Local~~\",\"destinationSessionId\":\"m_E2HZzEWyWyR6Y0zHGUKpMDouJziaKPWRlLOVm4\",\"status\":\"OK\",\"message\":\"Performed [Restart Deployment] on a [Application] given by Inventory path [/t;<%= tenant_id %>/f;<%= feed_id %>/r;Local~~]\"}"
     }
   ]
 ]


### PR DESCRIPTION
- new field ActionDefinition.global
- the alerts email plugin is no longer explicitly deployed, it is now
  embedded in hawkular-metrics.ear.

@josejulio Please review.  Note, I haven't really tested these changes (I'm not sure how).  The aren't expected to pass unless run against the Services PR with the updates.  Let me know if there is something I can do to validate.