### PR TITLE
Uniform Client names.

### DIFF
--- a/lib/hawkular/alerts/alerts_api.rb
+++ b/lib/hawkular/alerts/alerts_api.rb
@@ -13,7 +13,7 @@ module Hawkular::Alerts
   #   http://localhost:8080/hawkular/alerts
   # @param credentials [Hash{String=>String}] Hash of username, password, token(optional)
   # @param options [Hash{String=>String}] Additional rest client options
-  class AlertsClient < Hawkular::BaseClient
+  class Client < Hawkular::BaseClient
     def initialize(entrypoint, credentials = {}, options = {})
       entrypoint = normalize_entrypoint_url entrypoint, 'hawkular/alerts'
       @entrypoint = entrypoint
@@ -559,4 +559,7 @@ module Hawkular::Alerts
       super(event_hash)
     end
   end
+
+  AlertsClient = Client
+  deprecate_constant :AlertsClient if self.respond_to? :deprecate_constant
 end

--- a/lib/hawkular/hawkular_client.rb
+++ b/lib/hawkular/hawkular_client.rb
@@ -32,9 +32,9 @@ module Hawkular
     end
 
     def inventory
-      @inventory ||= Inventory::InventoryClient.create(entrypoint: "#{@state[:entrypoint]}/hawkular/inventory",
-                                                       credentials: @state[:credentials],
-                                                       options: @state[:options])
+      @inventory ||= Inventory::Client.new("#{@state[:entrypoint]}/hawkular/inventory",
+                                           @state[:credentials],
+                                           @state[:options])
     end
 
     def metrics
@@ -44,9 +44,9 @@ module Hawkular
     end
 
     def alerts
-      @alerts ||= Alerts::AlertsClient.new("#{@state[:entrypoint]}/hawkular/alerts",
-                                           @state[:credentials],
-                                           @state[:options])
+      @alerts ||= Alerts::Client.new("#{@state[:entrypoint]}/hawkular/alerts",
+                                     @state[:credentials],
+                                     @state[:options])
     end
 
     # adds a way to explicitly open the new web socket connection (the default is to recycle it)
@@ -57,18 +57,18 @@ module Hawkular
     end
 
     def tokens
-      @tokens ||= Token::TokenClient.new(@state[:entrypoint],
-                                         @state[:credentials],
-                                         @state[:options])
+      @tokens ||= Token::Client.new(@state[:entrypoint],
+                                    @state[:credentials],
+                                    @state[:options])
     end
 
     private
 
     # this is in a dedicated method, because constructor opens the websocket connection to make the handshake
     def init_operations_client
-      Operations::OperationsClient.new(entrypoint: @state[:entrypoint],
-                                       credentials: @state[:credentials],
-                                       options: @state[:options])
+      Operations::Client.new(entrypoint: @state[:entrypoint],
+                             credentials: @state[:credentials],
+                             options: @state[:options])
     end
   end
 end

--- a/lib/hawkular/inventory/inventory_api.rb
+++ b/lib/hawkular/inventory/inventory_api.rb
@@ -11,7 +11,7 @@ require 'hawkular/inventory/entities'
 #   and thus set to 'test' as default value.
 module Hawkular::Inventory
   # Client class to interact with Hawkular Inventory
-  class InventoryClient < Hawkular::BaseClient
+  class Client < Hawkular::BaseClient
     attr_reader :version
 
     # Create a new Inventory Client
@@ -35,7 +35,7 @@ module Hawkular::Inventory
       fail 'no parameter ":entrypoint" given' if hash[:entrypoint].nil?
       hash[:credentials] ||= {}
       hash[:options] ||= {}
-      InventoryClient.new(hash[:entrypoint], hash[:credentials], hash[:options])
+      Client.new(hash[:entrypoint], hash[:credentials], hash[:options])
     end
 
     # Retrieve the tenant id for the passed credentials.
@@ -565,4 +565,7 @@ module Hawkular::Inventory
       end
     end
   end
+
+  InventoryClient = Client
+  deprecate_constant :InventoryClient if self.respond_to? :deprecate_constant
 end

--- a/lib/hawkular/operations/operations_api.rb
+++ b/lib/hawkular/operations/operations_api.rb
@@ -27,7 +27,7 @@ end
 # Operations module allows invoking operation on the WildFly agent.
 module Hawkular::Operations
   # Client class to interact with the agent via websockets
-  class OperationsClient < Hawkular::BaseClient
+  class Client < Hawkular::BaseClient
     include WebSocket::Client
 
     attr_accessor :ws, :session_id
@@ -371,4 +371,7 @@ module Hawkular::Operations
       ret[0, 1].downcase + ret[1..-1]
     end
   end
+
+  OperationsClient = Client
+  deprecate_constant :OperationsClient if self.respond_to? :deprecate_constant
 end

--- a/lib/hawkular/tokens/tokens_api.rb
+++ b/lib/hawkular/tokens/tokens_api.rb
@@ -3,7 +3,7 @@ require 'hawkular/base_client'
 # Token module provides access to the Secret Store REST API.
 module Hawkular::Token
   # Client class to interact with the Secret Store
-  class TokenClient < Hawkular::BaseClient
+  class Client < Hawkular::BaseClient
     # Create a new Secret Store client
     # @param entrypoint [String] base url of Hawkular - e.g http://localhost:8080
     # @param credentials [Hash{String=>String}] Hash of username, password
@@ -31,4 +31,7 @@ module Hawkular::Token
       http_post('/secret-store/v1/tokens/create', token_attributes, auth_header)
     end
   end
+
+  TokenClient = Client
+  deprecate_constant :TokenClient if self.respond_to? :deprecate_constant
 end

--- a/spec/integration/alerts_spec.rb
+++ b/spec/integration/alerts_spec.rb
@@ -10,7 +10,7 @@ module Hawkular::Alerts::RSpec
     before(:all) do
       # Setup for testing
       record('Alert/Triggers', credentials, 'setup') do
-        @client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, credentials, options)
+        @client = Hawkular::Alerts::Client.new(ALERTS_BASE, credentials, options)
         json = IO.read('spec/integration/alert-resources/triggers-test-data.json')
         trigger_hash = JSON.parse(json)
         @client.bulk_import_triggers trigger_hash
@@ -20,7 +20,7 @@ module Hawkular::Alerts::RSpec
     after(:all) do
       # cleanup test values
       record('Alert/Triggers', credentials, 'setup_cleanup') do
-        @client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, credentials, options)
+        @client = Hawkular::Alerts::Client.new(ALERTS_BASE, credentials, options)
         json = IO.read('spec/integration/alert-resources/triggers-test-data.json')
         trigger_hash = JSON.parse(json)
         trigger_hash['triggers'].each do |trigger|
@@ -39,7 +39,7 @@ module Hawkular::Alerts::RSpec
     end
 
     before(:each) do
-      @client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds, options)
+      @client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds, options)
     end
 
     it 'Should List Triggers' do
@@ -229,7 +229,7 @@ module Hawkular::Alerts::RSpec
     end
 
     before(:each) do
-      @client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds, options)
+      @client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds, options)
     end
 
     it 'Should operate a complex group trigger' do
@@ -414,7 +414,7 @@ module Hawkular::Alerts::RSpec
     before(:all) do
       # Setup for testing
       record('Alert/Alerts', credentials, 'setup') do
-        @client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, credentials, options)
+        @client = Hawkular::Alerts::Client.new(ALERTS_BASE, credentials, options)
         json = IO.read('spec/integration/alert-resources/alerts-test-data.json')
         trigger_hash = JSON.parse(json)
         @client.bulk_import_triggers trigger_hash
@@ -429,7 +429,7 @@ module Hawkular::Alerts::RSpec
     after(:all) do
       # cleanup test values
       record('Alert/Alerts', credentials, 'setup_cleanup') do
-        @client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, credentials, options)
+        @client = Hawkular::Alerts::Client.new(ALERTS_BASE, credentials, options)
         json = IO.read('spec/integration/alert-resources/alerts-test-data.json')
         trigger_hash = JSON.parse(json)
         trigger_hash['triggers'].each do |trigger|
@@ -451,11 +451,11 @@ module Hawkular::Alerts::RSpec
     end
 
     before(:each) do
-      @client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds, options)
+      @client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds, options)
     end
 
     it 'Should list alerts' do
-      client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds, options)
+      client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds, options)
 
       alerts = client.list_alerts
 
@@ -464,7 +464,7 @@ module Hawkular::Alerts::RSpec
     end
 
     it 'Should list open alerts' do
-      client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds, options)
+      client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds, options)
 
       alerts = client.list_alerts('statuses' => 'OPEN')
 
@@ -473,7 +473,7 @@ module Hawkular::Alerts::RSpec
     end
 
     it 'Should list alerts for trigger' do
-      client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds, options)
+      client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds, options)
 
       alerts = client.get_alerts_for_trigger 'hello-world-trigger'
 
@@ -482,7 +482,7 @@ module Hawkular::Alerts::RSpec
     end
 
     it 'Should list alerts for unknown trigger' do
-      client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds, options)
+      client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds, options)
 
       alerts = client.get_alerts_for_trigger 'does-not-exist'
 
@@ -491,7 +491,7 @@ module Hawkular::Alerts::RSpec
     end
 
     it 'Should fetch single alert' do
-      client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds, options)
+      client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds, options)
 
       alert_id = client.list_alerts('statuses' => 'OPEN').first.id
 
@@ -502,7 +502,7 @@ module Hawkular::Alerts::RSpec
     end
 
     it 'Should resolve an alert' do
-      client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds, options)
+      client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds, options)
 
       alert_id = client.list_alerts('statuses' => 'OPEN').first.id
       alert = client.get_single_alert alert_id
@@ -517,7 +517,7 @@ module Hawkular::Alerts::RSpec
 
     # # TODO enable when the semantics on the server side is known
     #     it 'Should resolve an alert2' do
-    #       client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE,creds)
+    #       client = Hawkular::Alerts::Client.new(ALERTS_BASE,creds)
     #
     #       alert_id = '28026b36-8fe4-4332-84c8-524e173a68bf-snert~Local_jvm_garba-1446977734134'
     #       client.resolve_alert alert_id
@@ -525,7 +525,7 @@ module Hawkular::Alerts::RSpec
     #     end
 
     it 'Should acknowledge an alert' do
-      client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds, options)
+      client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds, options)
 
       alert_id = client.list_alerts('statuses' => 'OPEN').first.id
       client.get_single_alert alert_id
@@ -548,7 +548,7 @@ module Hawkular::Alerts::RSpec
     end
 
     before(:each) do
-      @client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds)
+      @client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds)
     end
 
     it 'Should return the version' do
@@ -561,7 +561,7 @@ module Hawkular::Alerts::RSpec
     before(:all) do
       # Setup for testing
       record('Alert/Events', credentials, 'setup') do
-        @client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, credentials, options)
+        @client = Hawkular::Alerts::Client.new(ALERTS_BASE, credentials, options)
         json = IO.read('spec/integration/alert-resources/events-test-data.json')
         hash = JSON.parse(json)
         hash['events'].each do |event|
@@ -573,7 +573,7 @@ module Hawkular::Alerts::RSpec
     after(:all) do
       # cleanup test values
       record('Alert/Events', credentials, 'setup_cleanup') do
-        @client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, credentials, options)
+        @client = Hawkular::Alerts::Client.new(ALERTS_BASE, credentials, options)
         json = IO.read('spec/integration/alert-resources/events-test-data.json')
         hash = JSON.parse(json)
         hash['events'].each do |event|
@@ -592,7 +592,7 @@ module Hawkular::Alerts::RSpec
     end
 
     it 'Should list events' do
-      client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds, options)
+      client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds, options)
 
       events = client.list_events('thin' => true)
 
@@ -601,7 +601,7 @@ module Hawkular::Alerts::RSpec
     end
 
     it 'Should list events using criteria' do
-      client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds, options)
+      client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds, options)
 
       events = client.list_events('categories' => %w(my-category-01 my-category-02))
 
@@ -610,7 +610,7 @@ module Hawkular::Alerts::RSpec
     end
 
     it 'Should not list events using criteria' do
-      client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds, options)
+      client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds, options)
 
       events = client.list_events('startTime' => 0, 'endTime' => 1000)
 
@@ -622,7 +622,7 @@ module Hawkular::Alerts::RSpec
       the_id = "test-event@#{Time.new.to_i}"
       VCR.eject_cassette
       record('Alert/Events', credentials.merge(id: the_id), cassette_name) do
-        client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds, options)
+        client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds, options)
 
         the_event = client.create_event(the_id, 'MyCategory', 'Li la lu',
                                         context: { message: 'This is a test' },
@@ -639,7 +639,7 @@ module Hawkular::Alerts::RSpec
       the_id = "test-event@#{Time.new.to_i}"
       VCR.eject_cassette
       record('Alert/Events', credentials.merge(id: the_id), cassette_name) do
-        client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds, options)
+        client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds, options)
         client.create_event(the_id, 'MyCategory', 'Li la lu',
                             context: { message: 'This is a test' },
                             tags: { tag_name: 'tag-value' })
@@ -662,7 +662,7 @@ module Hawkular::Alerts::RSpec
     end
 
     before(:each) do
-      @client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds, options)
+      @client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds, options)
     end
 
     it 'Should create and fire a trigger' do

--- a/spec/integration/hawkular_client_spec.rb
+++ b/spec/integration/hawkular_client_spec.rb
@@ -85,9 +85,9 @@ module Hawkular::Client::RSpec
       before(:all) do
         ::RSpec::Mocks.with_temporary_scope do
           mock_inventory_client '0.17.2.Final'
-          @client = Hawkular::Inventory::InventoryClient.create(entrypoint: HOST,
-                                                                credentials: @creds,
-                                                                options: { tenant: 'hawkular' })
+          @client = Hawkular::Inventory::Client.create(entrypoint: HOST,
+                                                       credentials: @creds,
+                                                       options: { tenant: 'hawkular' })
         end
       end
 
@@ -251,7 +251,7 @@ module Hawkular::Client::RSpec
           }
 
           actual_data = {}
-          client = Hawkular::Operations::OperationsClient.new(entrypoint: HOST, credentials: @creds)
+          client = Hawkular::Operations::Client.new(entrypoint: HOST, credentials: @creds)
           client.invoke_generic_operation(redeploy) do |on|
             on.success do |data|
               actual_data[:data] = data

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -71,7 +71,7 @@ module Hawkular::Inventory::RSpec
           VCR.eject_cassette
           record("Inventory/#{security_context}/Connection", @creds, cassette_name) do
             expect do
-              Hawkular::Inventory::InventoryClient.create(entrypoint: entrypoint, credentials: @creds)
+              Hawkular::Inventory::Client.create(entrypoint: entrypoint, credentials: @creds)
             end.to raise_error(Hawkular::BaseClient::HawkularException, 'Unauthorized')
           end
         end

--- a/spec/integration/operations_spec.rb
+++ b/spec/integration/operations_spec.rb
@@ -47,7 +47,7 @@ module Hawkular::Operations::RSpec
       end
 
       let(:client) do
-        OperationsClient.new(options)
+        Client.new(options)
       end
 
       before(:all) do
@@ -73,7 +73,7 @@ module Hawkular::Operations::RSpec
         it 'should be established via entrypoint' do
           ep = host_with_scheme(host, security_context == SECURE_CONTEXT)
 
-          client = OperationsClient.new(options.merge entrypoint: ep, host: nil)
+          client = Client.new(options.merge entrypoint: ep, host: nil)
           ws = client.ws
           expect(ws).not_to be nil
           expect(ws.open?).to be true
@@ -126,7 +126,7 @@ module Hawkular::Operations::RSpec
 
         it 'should bail with no host' do
           expect do
-            OperationsClient.new(options.merge host: nil)
+            Client.new(options.merge host: nil)
           end.to raise_error(StandardError, 'no parameter ":host" or ":entrypoint" given')
         end
       end
@@ -141,7 +141,7 @@ module Hawkular::Operations::RSpec
           record("Operation/#{security_context}/Helpers", nil, 'get_tenant') do
             ::RSpec::Mocks.with_temporary_scope do
               mock_inventory_client
-              @inventory_client = InventoryClient.create(
+              @inventory_client = ::Hawkular::Inventory::Client.create(
                 options.merge entrypoint: host_with_scheme(host, security_context == SECURE_CONTEXT))
             end
             inventory_client = @inventory_client

--- a/spec/integration/tokens_spec.rb
+++ b/spec/integration/tokens_spec.rb
@@ -7,7 +7,7 @@ module Hawkular::Token::RSpec
     it 'Should be able to list the available tokens' do
       creds = { username: 'jdoe', password: 'password' }
       options = { tenant: 'hawkular' }
-      client = Hawkular::Token::TokenClient.new(HAWKULAR_BASE, creds, options)
+      client = Hawkular::Token::Client.new(HAWKULAR_BASE, creds, options)
       tokens = client.get_tokens(creds)
       expect(tokens).to be_empty
     end
@@ -15,7 +15,7 @@ module Hawkular::Token::RSpec
     it 'Should be able to create a new token for an actual user' do
       creds = { username: 'jdoe', password: 'password' }
       options = { tenant: 'hawkular' }
-      client = Hawkular::Token::TokenClient.new(HAWKULAR_BASE, creds, options)
+      client = Hawkular::Token::Client.new(HAWKULAR_BASE, creds, options)
       token = client.create_token(creds)
       expect(token['key']).not_to be_nil
       expect(token['secret']).not_to be_nil
@@ -25,7 +25,7 @@ module Hawkular::Token::RSpec
     it 'Should get a 401 when attempting to create a token with a wrong password' do
       creds = { username: 'jdoe', password: 'mywrongpassword' }
       options = { tenant: 'hawkular' }
-      client = Hawkular::Token::TokenClient.new(HAWKULAR_BASE, creds, options)
+      client = Hawkular::Token::Client.new(HAWKULAR_BASE, creds, options)
       begin
         client.create_token(creds)
         fail 'Should have failed with 401'
@@ -37,7 +37,7 @@ module Hawkular::Token::RSpec
     it 'Should get a 401 when attempting to create a token without a password' do
       creds = { username: 'jdoe', password: '' }
       options = { tenant: 'hawkular' }
-      client = Hawkular::Token::TokenClient.new(HAWKULAR_BASE, creds, options)
+      client = Hawkular::Token::Client.new(HAWKULAR_BASE, creds, options)
       begin
         client.create_token(creds)
         fail 'Should have failed with 401'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,11 +18,11 @@ module Hawkular::Inventory::RSpec
       username: options[:username].nil? ? config['user'] : options[:username],
       password: options[:password].nil? ? config['password'] : options[:password]
     }
-    @client = Hawkular::Inventory::InventoryClient.new(entrypoint, credentials, options)
+    @client = Hawkular::Inventory::Client.new(entrypoint, credentials, options)
   end
 
   def mock_inventory_client(for_version = '0.16.1.Final')
-    allow_any_instance_of(Hawkular::Inventory::InventoryClient).to receive(:fetch_version_and_status).and_return(
+    allow_any_instance_of(Hawkular::Inventory::Client).to receive(:fetch_version_and_status).and_return(
       'Implementation-Version' => for_version
     )
   end


### PR DESCRIPTION
Added backwards compatibility for old names, but marked them as
deprecated.