### PR TITLE
Add an entrypoint for requires of the gem

### DIFF
--- a/lib/hawkular/hawkular_client.rb
+++ b/lib/hawkular/hawkular_client.rb
@@ -1,5 +1,5 @@
 require 'hawkular/inventory/inventory_api'
-require 'hawkular/metrics/metrics_client.rb'
+require 'hawkular/metrics/metrics_client'
 require 'hawkular/alerts/alerts_api'
 require 'hawkular/tokens/tokens_api'
 require 'hawkular/operations/operations_api'

--- a/lib/hawkularclient.rb
+++ b/lib/hawkularclient.rb
@@ -1,0 +1,8 @@
+require 'hawkular/version'
+require 'hawkular/inventory/inventory_api'
+require 'hawkular/metrics/metrics_client'
+require 'hawkular/alerts/alerts_api'
+require 'hawkular/tokens/tokens_api'
+require 'hawkular/operations/operations_api'
+require 'hawkular/base_client'
+require 'hawkular/hawkular_client'


### PR DESCRIPTION
Currently you have to add a `require: ` flag when you add the gem on the `Gemfile`. This PR fixes the problem.