### PR TITLE
Fix old usages of internal constants

### DIFF
--- a/lib/hawkular/client_utils.rb
+++ b/lib/hawkular/client_utils.rb
@@ -37,3 +37,6 @@ module Hawkular
     end
   end
 end
+
+HawkularUtilsMixin = Hawkular::ClientUtils
+deprecate_constant(:HawkularUtilsMixin) if self.respond_to?(:deprecate_constant)

--- a/spec/unit/deprecations_spec.rb
+++ b/spec/unit/deprecations_spec.rb
@@ -1,0 +1,19 @@
+require_relative '../spec_helper'
+
+describe 'Deprecations' do
+  def self.changed_constant(from:, to:)
+    describe to do
+      it 'is still accessible by its old name' do
+        expect(from).to eq to
+      end
+    end
+  end
+
+  describe 'pre-3.0' do
+    changed_constant from: HawkularUtilsMixin, to: Hawkular::ClientUtils
+    changed_constant from: Hawkular::Operations::OperationsClient, to: Hawkular::Operations::Client
+    changed_constant from: Hawkular::Alerts::AlertsClient, to: Hawkular::Alerts::Client
+    changed_constant from: Hawkular::Token::TokenClient, to: Hawkular::Token::Client
+    changed_constant from: Hawkular::Inventory::InventoryClient, to: Hawkular::Inventory::Client
+  end
+end


### PR DESCRIPTION
This PR re-adds the `HawkularUtilsMixin` constant (I wasn't aware it was being used directly on ManageIQ), and also adds tests for documenting planned deprecations.