### PR TITLE
Automatic generation of documentation in Travis in case of release.

### DIFF
--- a/.travis.docs.rb
+++ b/.travis.docs.rb
@@ -31,7 +31,7 @@ def copy_docs
   `cp -r #{DOCS_DIR} docs/#{VERSION}`
   `rm docs/latest`
   `ln -s #{VERSION} docs/latest`
-  `echo "      <li><a href='/docs/#{VERSION}'>#{VERSION}</a></li>" >> docs/index.html`
+  `echo "      <li><a href='/hawkular-client-ruby/docs/#{VERSION}'>#{VERSION}</a></li>" >> docs/index.html`
 end
 
 def add_to_scm

--- a/.travis.docs.rb
+++ b/.travis.docs.rb
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+
+def check_preconditions
+  exit 1 if ENV['TRAVIS_SECURE_ENV_VARS'] != 'true'
+  exit 1 if !ENV['GH_TOKEN']
+  exit 1 if ENV['CI'] != 'true'
+  exit 1 if ENV['TRAVIS_PULL_REQUEST'] != 'false'
+  if !ENV['TRAVIS_TAG'] || ENV['TRAVIS_TAG'] !~ /^v\d{1,2}\.\d{1,2}\.\d{1,2}$/
+    puts 'Skipping the docs generation because it\'s not a release build.'
+    exit 0
+  end
+end
+check_preconditions
+
+def version
+  ENV['TRAVIS_TAG'][1..-1]
+end
+
+VERSION=version
+DOCS_DIR='~/doc'
+
+def switch_branch
+  `git checkout gh-pages`
+end
+
+def generate_docs
+  `yardoc --output-dir #{DOCS_DIR}`
+end
+
+def copy_docs
+  `cp -r #{DOCS_DIR} docs/#{VERSION}`
+  `rm docs/latest`
+  `ln -s #{VERSION} docs/latest`
+  `echo "      <li><a href='/docs/#{VERSION}'>#{VERSION}</a></li>" >> docs/index.html`
+end
+
+def add_to_scm
+  `git add -A`
+  `git commit -m "Docs for version #{VERSION}."`
+  `git remote add ad-hoc-origin https://hawkular-website-bot:#{GH_TOKEN}@github.com/hawkular/hawkular-client-ruby.git`
+  `git push ad-hoc-origin gh-pages`
+end
+
+def main
+  puts 'generating docs for version ' + VERSION
+  generate_docs
+
+  puts 'switching branch to gh-pages..'
+  switch_branch
+
+  puts 'copying docs..'
+  copy_docs
+  
+  puts 'pushing back to gh-pages..'
+  add_to_scm
+end
+
+main

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ rvm:
 env:
   global:
     - ADMIN_TOKEN=4f4a1434-8cb3-11e6-ae22-56b6b6499611
+    # GH_TOKEN=...  used by hawkular-website-bot to publish the documentation
+    - secure: "EpOp9rU8GW2v/QyuDFRZQPQ2vGZ8vPsheVvLE7KSsu3UjNF8STiE50a2gmUW6KYQU+8jwSDHl8zUjIgpBko1tAUMd4NXNPMxZA+ybBLyUwQbbkTvFcG7FVFeB0UyjPQzOAw7qLm53HvknDv/P65OgkWXfjUVFWo4plgZKdwufDHyUqyN1ZBOUKu1w8HZ00HLnUWkhSiV9YG4RRFKJfEriElyv24L0RA9X8yVsS1eGr9MJhTzVgF0bAW6dSyxarZEo4qvLnqko98mva/wfGkmIBJBy7wxBSfy92flSh44s+s/nPzNKh1vZ9RF5lUekvh3Iw3pzZ9gb9wiNIvVM3Fa3jRl82fFUsGmpD2frE0cy4us+YodvPpAYn2EgGoVQnTJaFCTeMRbQpQ67j71JO6fBxGkIHb+TtdyieVajPGlRnJa6RDpT2QDiwuzhOOMvNkxO+6k+87ePUGu3geng7RXIBV3FqsjfkY79cDo3EsVg95BAa2rEuyqysbdVWox1VK0QuvBaFtNCbBoegnk0PX0uNMKmt1cLsxvz5zfwgAVPTEXsa8/FcDC2X6Ua+oVmSVZTEW1anEjQUjz+CYwWaBTwXknZvRNsM3x/kYskVyieDzehu71L5exZtg6+P+In6N/NXw7DL0SokPE4VbPng71eOlMW3cTDnnxeR1fmffABGg="
   matrix:
     - RUN_ON_LIVE_SERVER=1 \
       VCR_UPDATE=1 \
@@ -18,3 +20,5 @@ services:
   - docker
 before_install:
   - (test $RUN_ON_LIVE_SERVER = 1 && ./.travis/start_hawkular_services.sh -d && ./.travis/wait_for_services.rb) || echo "Skipping live server"
+after_success:
+  - ./.travis.docs.rb

--- a/.yardopts
+++ b/.yardopts
@@ -1,1 +1,7 @@
-- CHANGES.rdoc api_breaking_changes.rdoc
+--protected
+--no-private
+--readme README.rdoc
+-
+CHANGES.rdoc
+api_breaking_changes.rdoc
+LICENSE

--- a/README.rdoc
+++ b/README.rdoc
@@ -6,12 +6,12 @@
 
 A Ruby Hawkular Client.
 
-Documentation[http://www.hawkular.org/hawkular-client-ruby/]
+Documentation[http://www.hawkular.org/hawkular-client-ruby/docs/]
 
 == Changelog
 
-See {CHANGELOG}[link:file.CHANGES.html] for a list of changes and
-{API-Breaking-Changes}[link:file.api_breaking_changes.html] for a list of api-breaking changes.
+See {CHANGELOG}[http://www.hawkular.org/docs/latest/hawkular-client-ruby/file.CHANGES.html] for a list of changes and
+{API-Breaking-Changes}[link:http://www.hawkular.org/docs/latest/hawkular-client-ruby/file.api_breaking_changes.html] for a list of api-breaking changes.
 
 == Overview
 
@@ -49,7 +49,7 @@ Metrics API is also subdivided to: Mixed, Availability, Counters, Gauges and Ten
   client.metrics.tenants # Tenants
 
 The Mixed API is capable of handling multiple types of metrics, like the
-push_data[Hawkular/Metrics/Client.html#push_data-instance_method] method, which pushes data
+push_data[http://www.hawkular.org/hawkular-client-ruby/docs/latest/Hawkular/Metrics/Client.html#push_data-instance_method] method, which pushes data
 for multiple metrics of all supported data.
 
 You can also access each subproject's API individually, if you would like to use only the metrics API you could do
@@ -102,20 +102,20 @@ Each network01_avail will be an array like:
     # ...
   ]
 
-You can get more info on the other parameters by checking the metrics API get_data[Hawkular/Metrics/Client/Metrics#get_data-instance_method]
+You can get more info on the other parameters by checking the metrics API get_data[http://www.hawkular.org/hawkular-client-ruby/docs/latest/Hawkular/Metrics/Client/Metrics#get_data-instance_method]
 
 === More info
 
 Check each resource API for a detailed description of what methods are available.
-* Alerts[Hawkular/Alerts/AlertsClient.html]
-* Inventory[Hawkular/Inventory/InventoryClient.html]
+* Alerts[http://www.hawkular.org/hawkular-client-ruby/docs/latest/Hawkular/Alerts/AlertsClient.html]
+* Inventory[http://www.hawkular.org/hawkular-client-ruby/docs/latest/Hawkular/Inventory/InventoryClient.html]
 * Metrics:
-  * Mixed[Hawkular/Metrics/Client.html]
-  * Availability[Hawkular/Metrics/Client/Availability.html]
-  * Counters[Hawkular/Metrics/Client/Counters.html]
-  * Gauges[Hawkular/Metrics/Client/Gauges.html]
-  * Tenants[Hawkular/Metrics/Client/Tenants.html]
-* Operations[Hawkular/Operations/OperationsClient.html]
+  * Mixed[http://www.hawkular.org/hawkular-client-ruby/docs/latest/Hawkular/Metrics/Client.html]
+  * Availability[http://www.hawkular.org/hawkular-client-ruby/docs/latest/Hawkular/Metrics/Client/Availability.html]
+  * Counters[http://www.hawkular.org/hawkular-client-ruby/docs/latest/Hawkular/Metrics/Client/Counters.html]
+  * Gauges[http://www.hawkular.org/hawkular-client-ruby/docs/latest/Hawkular/Metrics/Client/Gauges.html]
+  * Tenants[http://www.hawkular.org/hawkular-client-ruby/docs/latest/Hawkular/Metrics/Client/Tenants.html]
+* Operations[http://www.hawkular.org/hawkular-client-ruby/docs/latest/Hawkular/Operations/OperationsClient.html]
 
 == Contributing to hawkular-client-ruby
 
@@ -145,7 +145,7 @@ Integration tests are recorded and played against cassettes recorded with VCR
 * Currently, we support two posible metrics contexts: <code>hawkular-metrics 0.8.0.Final</code> and <code>hawkular-services</code> that contain metrics. If you want to run/re-record the tests only for services, you can skip the other context by <code>SKIP_V8_METRICS=1</code>, or similarly <code>SKIP_SERVICES_METRICS=1</code>. So for instance updating the VCR templates only for hawkular-services would require command:
     VCR_UPDATE=1 SKIP_V8_METRICS=1 rspec ./spec/integration/metric_spec.rb
 
-For more details consult the {spec readme}[link:spec/README.rdoc].
+For more details consult the {spec readme}[link:http://www.hawkular.org/docs/latest/hawkular-client-ruby/file.README.html].
 
 == Logging
 

--- a/hawkularclient.gemspec
+++ b/hawkularclient.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
     A Ruby client for Hawkular
   EOS
 
-  gem.files         = `git ls-files -z`.split("\x0")
+  gem.files         = `git ls-files -z lib LICENSE README.rdoc`.split("\x0")
   gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']


### PR DESCRIPTION
This PR basically does as described in these 2 comments:
* https://github.com/hawkular/hawkular-client-ruby/issues/101#issuecomment-286608438
* https://github.com/hawkular/hawkular-client-ruby/issues/101#issuecomment-286607493

There is also related PR to the gh-pages branch - https://github.com/hawkular/hawkular-client-ruby/pull/199

Also there is no need to have those travis specific scripts, docker-compose files, .coveralls configs and other files in the released gem, so I removed them from the white list here: https://github.com/hawkular/hawkular-client-ruby/pull/198/files#diff-a5831e69d9fde06f5c110544c9e14a1aR19