### PR TITLE
[HAWKULAR-1206] Add timestamps parameter due to changes in HWKMETRICS…

### DIFF
--- a/lib/hawkular/metrics/metric_api.rb
+++ b/lib/hawkular/metrics/metric_api.rb
@@ -129,10 +129,13 @@ module Hawkular::Metrics
 
       # Query metric definitions by tags
       # @param tags [Hash]
+      # @param options [Hash] Additional options to configure
+      # @option options [Boolean] :timestamps If timestamps should be included on the response. Defaults to true
       # @return [Array[MetricDefinition]]
-      def query(tags = nil)
+      def query(tags = nil, options = {})
+        timestamps = (options.key?(:timestamps) ? options[:timestamps] : true).to_s
         tags_filter = tags.nil? ? '' : "&tags=#{@client.tags_param(tags)}"
-        @client.http_get("/metrics/?type=#{@type}#{tags_filter}").map do |g|
+        @client.http_get("/metrics/?timestamps=#{timestamps}&type=#{@type}#{tags_filter}").map do |g|
           Hawkular::Metrics::MetricDefinition.new(g)
         end
       end

--- a/spec/vcr_cassettes/Metrics/NonSecure/metrics_0_8_0/Templates/Availability_metrics/Should_update_tags_for_Availability_definition.yml
+++ b/spec/vcr_cassettes/Metrics/NonSecure/metrics_0_8_0/Templates/Availability_metrics/Should_update_tags_for_Availability_definition.yml
@@ -160,7 +160,7 @@ http_interactions:
   recorded_at: Thu, 30 Jun 2016 16:31:37 GMT
 - request:
     method: get
-    uri: http://localhost:8080/hawkular/metrics/metrics/?tags=myTag:<%= id %>&type=availability
+    uri: http://localhost:8080/hawkular/metrics/metrics/?tags=myTag:<%= id %>&timestamps=true&type=availability
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/Metrics/NonSecure/metrics_0_8_0/Templates/Gauge_metrics/Should_update_tags_for_gauge_definition.yml
+++ b/spec/vcr_cassettes/Metrics/NonSecure/metrics_0_8_0/Templates/Gauge_metrics/Should_update_tags_for_gauge_definition.yml
@@ -160,7 +160,7 @@ http_interactions:
   recorded_at: Thu, 30 Jun 2016 16:31:38 GMT
 - request:
     method: get
-    uri: http://localhost:8080/hawkular/metrics/metrics/?tags=myTag:<%= id %>&type=gauge
+    uri: http://localhost:8080/hawkular/metrics/metrics/?tags=myTag:<%= id %>&timestamps=true&type=gauge
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/Metrics/NonSecure/metrics_services/Templates/Availability_metrics/Should_update_tags_for_Availability_definition.yml
+++ b/spec/vcr_cassettes/Metrics/NonSecure/metrics_services/Templates/Availability_metrics/Should_update_tags_for_Availability_definition.yml
@@ -39,7 +39,7 @@ http_interactions:
       Location:
       - http://localhost:8080/hawkular/metrics/availability/<%= id %>
       Date:
-      - Mon, 15 Aug 2016 15:20:37 GMT
+      - Wed, 22 Mar 2017 19:52:26 GMT
       Connection:
       - keep-alive
       Content-Length:
@@ -48,7 +48,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 15 Aug 2016 15:20:37 GMT
+  recorded_at: Wed, 22 Mar 2017 19:52:26 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/<%= id %>
@@ -84,7 +84,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 15 Aug 2016 15:20:37 GMT
+      - Wed, 22 Mar 2017 19:52:26 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -95,7 +95,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"id":"<%= id %>","tags":{"myTag":"<%= id %>"},"dataRetention":7,"type":"availability","tenantId":"<%= vcr_test_tenant %>"}'
     http_version: 
-  recorded_at: Mon, 15 Aug 2016 15:20:37 GMT
+  recorded_at: Wed, 22 Mar 2017 19:52:26 GMT
 - request:
     method: put
     uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/<%= id %>/tags
@@ -137,12 +137,12 @@ http_interactions:
       Content-Length:
       - '0'
       Date:
-      - Mon, 15 Aug 2016 15:20:37 GMT
+      - Wed, 22 Mar 2017 19:52:26 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 15 Aug 2016 15:20:37 GMT
+  recorded_at: Wed, 22 Mar 2017 19:52:26 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/metrics/availability/<%= id %>
@@ -178,7 +178,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 15 Aug 2016 15:20:37 GMT
+      - Wed, 22 Mar 2017 19:52:26 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -189,10 +189,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"id":"<%= id %>","tags":{"myTag":"<%= id %>","newTag":"newValue"},"dataRetention":7,"type":"availability","tenantId":"<%= vcr_test_tenant %>"}'
     http_version: 
-  recorded_at: Mon, 15 Aug 2016 15:20:37 GMT
+  recorded_at: Wed, 22 Mar 2017 19:52:26 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/metrics/?tags=myTag:<%= id %>&type=availability
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/metrics/?tags=myTag:<%= id %>&timestamps=true&type=availability
     body:
       encoding: US-ASCII
       string: ''
@@ -225,7 +225,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 15 Aug 2016 15:20:37 GMT
+      - Wed, 22 Mar 2017 19:52:26 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -236,5 +236,5 @@ http_interactions:
       encoding: UTF-8
       string: '[{"id":"<%= id %>","tags":{"myTag":"<%= id %>","newTag":"newValue"},"dataRetention":7,"type":"availability","tenantId":"<%= vcr_test_tenant %>"}]'
     http_version: 
-  recorded_at: Mon, 15 Aug 2016 15:20:37 GMT
+  recorded_at: Wed, 22 Mar 2017 19:52:26 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/NonSecure/metrics_services/Templates/Availability_metrics/setup_client.yml
+++ b/spec/vcr_cassettes/Metrics/NonSecure/metrics_services/Templates/Availability_metrics/setup_client.yml
@@ -14,7 +14,7 @@ http_interactions:
       User-Agent:
       - hawkular-client-ruby
       Hawkular-Tenant:
-      - <%= type %>metrics_services-vcr-tenant-bb1eb255-4bcb-4dbe-9253-d32fbcfd134c
+      - <%= type %>metrics_services-vcr-tenant-9a0f8a39-7e06-4614-9a6f-51cb8ea418a5
       Content-Type:
       - application/json
       Host:
@@ -33,12 +33,12 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '133'
+      - '150'
       Date:
-      - Thu, 13 Oct 2016 03:23:56 GMT
+      - Wed, 22 Mar 2017 19:52:26 GMT
     body:
       encoding: UTF-8
-      string: '{"MetricsService":"STARTED","Implementation-Version":"0.20.1.Final","Built-From-Git-SHA1":"f23946235446d3425db31d262b47b4f950ddabb3"}'
+      string: '{"MetricsService":"STARTED","Implementation-Version":"0.24.1.Final","Built-From-Git-SHA1":"397e6ce2e56828276c6c38a8ae04ecadb548a101","Cassandra":"up"}'
     http_version: 
-  recorded_at: Thu, 13 Oct 2016 03:23:56 GMT
+  recorded_at: Wed, 22 Mar 2017 19:52:26 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/NonSecure/metrics_services/Templates/Gauge_metrics/Should_update_tags_for_gauge_definition.yml
+++ b/spec/vcr_cassettes/Metrics/NonSecure/metrics_services/Templates/Gauge_metrics/Should_update_tags_for_gauge_definition.yml
@@ -39,7 +39,7 @@ http_interactions:
       Location:
       - http://localhost:8080/hawkular/metrics/gauges/<%= id %>
       Date:
-      - Mon, 15 Aug 2016 15:20:37 GMT
+      - Wed, 22 Mar 2017 19:46:01 GMT
       Connection:
       - keep-alive
       Content-Length:
@@ -48,7 +48,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 15 Aug 2016 15:20:37 GMT
+  recorded_at: Wed, 22 Mar 2017 19:46:01 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>
@@ -84,7 +84,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 15 Aug 2016 15:20:37 GMT
+      - Wed, 22 Mar 2017 19:46:01 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -95,7 +95,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"id":"<%= id %>","tags":{"myTag":"<%= id %>"},"dataRetention":7,"type":"gauge","tenantId":"<%= vcr_test_tenant %>"}'
     http_version: 
-  recorded_at: Mon, 15 Aug 2016 15:20:37 GMT
+  recorded_at: Wed, 22 Mar 2017 19:46:01 GMT
 - request:
     method: put
     uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>/tags
@@ -137,12 +137,12 @@ http_interactions:
       Content-Length:
       - '0'
       Date:
-      - Mon, 15 Aug 2016 15:20:37 GMT
+      - Wed, 22 Mar 2017 19:46:01 GMT
     body:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Mon, 15 Aug 2016 15:20:37 GMT
+  recorded_at: Wed, 22 Mar 2017 19:46:01 GMT
 - request:
     method: get
     uri: http://jdoe:password@localhost:8080/hawkular/metrics/gauges/<%= id %>
@@ -178,7 +178,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 15 Aug 2016 15:20:37 GMT
+      - Wed, 22 Mar 2017 19:46:01 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -189,10 +189,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"id":"<%= id %>","tags":{"myTag":"<%= id %>","newTag":"newValue"},"dataRetention":7,"type":"gauge","tenantId":"<%= vcr_test_tenant %>"}'
     http_version: 
-  recorded_at: Mon, 15 Aug 2016 15:20:37 GMT
+  recorded_at: Wed, 22 Mar 2017 19:46:01 GMT
 - request:
     method: get
-    uri: http://jdoe:password@localhost:8080/hawkular/metrics/metrics/?tags=myTag:<%= id %>&type=gauge
+    uri: http://jdoe:password@localhost:8080/hawkular/metrics/metrics/?tags=myTag:<%= id %>&timestamps=true&type=gauge
     body:
       encoding: US-ASCII
       string: ''
@@ -225,7 +225,7 @@ http_interactions:
       Pragma:
       - no-cache
       Date:
-      - Mon, 15 Aug 2016 15:20:37 GMT
+      - Wed, 22 Mar 2017 19:46:01 GMT
       Connection:
       - keep-alive
       Content-Type:
@@ -236,5 +236,5 @@ http_interactions:
       encoding: UTF-8
       string: '[{"id":"<%= id %>","tags":{"myTag":"<%= id %>","newTag":"newValue"},"dataRetention":7,"type":"gauge","tenantId":"<%= vcr_test_tenant %>"}]'
     http_version: 
-  recorded_at: Mon, 15 Aug 2016 15:20:37 GMT
+  recorded_at: Wed, 22 Mar 2017 19:46:01 GMT
 recorded_with: VCR 3.0.3

--- a/spec/vcr_cassettes/Metrics/NonSecure/metrics_services/Templates/Gauge_metrics/setup_client.yml
+++ b/spec/vcr_cassettes/Metrics/NonSecure/metrics_services/Templates/Gauge_metrics/setup_client.yml
@@ -14,7 +14,7 @@ http_interactions:
       User-Agent:
       - hawkular-client-ruby
       Hawkular-Tenant:
-      - <%= type %>metrics_services-vcr-tenant-e034c355-5c5e-4a5e-8258-242088759e96
+      - <%= type %>metrics_services-vcr-tenant-74c6db5d-3e7c-4801-a5fb-09da04432201
       Content-Type:
       - application/json
       Host:
@@ -33,12 +33,12 @@ http_interactions:
       Content-Type:
       - application/json
       Content-Length:
-      - '133'
+      - '150'
       Date:
-      - Thu, 13 Oct 2016 03:30:38 GMT
+      - Wed, 22 Mar 2017 19:46:01 GMT
     body:
       encoding: UTF-8
-      string: '{"MetricsService":"STARTED","Implementation-Version":"0.20.1.Final","Built-From-Git-SHA1":"f23946235446d3425db31d262b47b4f950ddabb3"}'
+      string: '{"MetricsService":"STARTED","Implementation-Version":"0.24.1.Final","Built-From-Git-SHA1":"397e6ce2e56828276c6c38a8ae04ecadb548a101","Cassandra":"up"}'
     http_version: 
-  recorded_at: Thu, 13 Oct 2016 03:30:38 GMT
+  recorded_at: Wed, 22 Mar 2017 19:46:01 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
…-625

- The new parameter is optional and defaults to true to avoid breaking any existing code.

Similar to #197 but with argument `options` which could have `:timestamps` and recorded the cassettes.