### PR TITLE
trivial: removing the use of the deprecated constant

### DIFF
--- a/spec/integration/alerts_spec.rb
+++ b/spec/integration/alerts_spec.rb
@@ -537,7 +537,7 @@ module Hawkular::Alerts::RSpec
     end
 
     it 'Should add tags to existing alert' do
-      client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds, options)
+      client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds, options)
       alert_id = client.list_alerts.first.id
       alert_not_found = client.list_alerts(tags: 'new-tag-name|tag_value', thin: true).first
       client.add_tags([alert_id], ['new-tag-name|tag_value', 'othertag|othervalue'])
@@ -548,7 +548,7 @@ module Hawkular::Alerts::RSpec
     end
 
     it 'Should remove tags from existing alert' do
-      client = Hawkular::Alerts::AlertsClient.new(ALERTS_BASE, creds, options)
+      client = Hawkular::Alerts::Client.new(ALERTS_BASE, creds, options)
       alert_id = client.list_alerts.first.id
       client.add_tags([alert_id], ['new-tag-name|tag_value', 'othertag|othervalue'])
       alert_found_by_new_tag_name = client.list_alerts(tags: 'new-tag-name|tag_value', thin: true).first


### PR DESCRIPTION
it's annoying to see it when running `rspec`:

before:
```bash
...................../home/jkremser/workspace/hawkular-client-ruby/spec/integration/alerts_spec.rb:540: warning: constant Hawkular::Alerts::AlertsClient is deprecated
./home/jkremser/workspace/hawkular-client-ruby/spec/integration/alerts_spec.rb:551: warning: constant Hawkular::Alerts::AlertsClient is deprecated
...............................................................................**..**...*.......*......**.******....................................................................................................
```

after:
```bash
.....................................................................................................**..**...*.......*......**.******....................................................................................................
```