### PR TITLE
Operation callbacks fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ services:
   - docker
 before_install:
   - (test $RUN_ON_LIVE_SERVER = 1 && docker-compose up -d && ./.travis/wait_for_services.rb) || echo "Skipping live server"
+  - gem update bundler
 # Lets wait a bit for the agent to load everything it needs.
 before_script:
   - (test $RUN_ON_LIVE_SERVER = 1 && sleep 20s) || true

--- a/hawkularclient.gemspec
+++ b/hawkularclient.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rubocop', '= 0.34.2')
   gem.add_development_dependency('coveralls')
   gem.add_development_dependency('rack', '~> 1.6.4')
+  gem.add_development_dependency('pry-byebug')
 
   gem.rdoc_options << '--title' << gem.name <<
     '--main' << 'README.rdoc' << '--line-numbers' << '--inline-source'

--- a/lib/hawkular/operations/operations_api.rb
+++ b/lib/hawkular/operations/operations_api.rb
@@ -338,7 +338,8 @@ module Hawkular::Operations
         when "#{operation_name}Response"
           same_path = parsed[:data]['resourcePath'] == operation_payload[:resourcePath]
           # failed operations don't return the operation name from some strange reason
-          same_name = parsed[:data]['operationName'] == operation_payload[:operationName]
+          same_name = operation_payload[:operationName].nil? ||
+                      parsed[:data]['operationName'] == operation_payload[:operationName].to_s
           if same_path # using the resource path as a correlation id
             success = same_name && parsed[:data]['status'] == 'OK'
             success ? callback.perform(:success, parsed[:data]) : callback.perform(:failure, parsed[:data]['message'])


### PR DESCRIPTION
Created branch 2.8.x on the repo from v2.8.0 tag. On top of that branch/tag, cherry-picked commit 49fc84a. I will need this released as v2.8.1.

This is required to fix BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1443005.

Note 1: v2.9.0 included that commit/fix, so there is no problem in that version.
Note 2: Travis is raising errors when testing on live servers. I don't know why that's happening :disappointed:. In travis log, something is echoed saying that hawkular-services was the one that failed to perform an operation. So, may be the problem is somewhere else?  