### PR TITLE
fixing typos in release notes and adding the release notes for 3.0.1

### DIFF
--- a/CHANGES.rdoc
+++ b/CHANGES.rdoc
@@ -4,6 +4,9 @@ This document describes the relevant changes between releases of the
 _hawkular-client_ project.
 
 
+=== V 3.0.1
+* Fixed the issue in operations client when dealing with error handling
+
 === V 3.0.0
 * Starting this version the older Hawkular Services (prior version 0.36.0.Final, excluding) are not compatible
 * We added support for multitenancy
@@ -22,7 +25,7 @@ _hawkular-client_ project.
 11. <code>create_metric_for_resource</code> - removed
 12. <code>events</code> - removed
 13. <code>no_more_events!</code> - removed
-14. <code>list_metrics_for_resource_type
+14. <code>list_metrics_for_resource_type</code> - removed
 15. <code>list_resource_types(feed_id)</code> - now the feed_id parameter is mandatory
 
 Also the payload/parameters are now different:

--- a/README.rdoc
+++ b/README.rdoc
@@ -11,7 +11,7 @@ Documentation[http://www.hawkular.org/hawkular-client-ruby/docs/]
 == Changelog
 
 See {CHANGELOG}[http://www.hawkular.org/hawkular-client-ruby/docs/latest/file.CHANGES.html] for a list of changes and
-{API-Breaking-Changes}[link:http://www.hawkular.org/hawkular-client-ruby/docs/latest/file.api_breaking_changes.html] for a list of api-breaking changes.
+{API-Breaking-Changes}[http://www.hawkular.org/hawkular-client-ruby/docs/latest/file.api_breaking_changes.html] for a list of api-breaking changes.
 
 == Overview
 

--- a/api_breaking_changes.rdoc
+++ b/api_breaking_changes.rdoc
@@ -16,7 +16,7 @@
 11. <code>create_metric_for_resource</code> - removed
 12. <code>events</code> - removed
 13. <code>no_more_events!</code> - removed
-14. <code>list_metrics_for_resource_type
+14. <code>list_metrics_for_resource_type</code> - removed
 15. <code>list_resource_types(feed_id)</code> - now the feed_id parameter is mandatory
 
 * instead of <code>Hawkular::Inventory::CanonicalPath.to_resource</code> use <code>Hawkular::Inventory::CanonicalPath.down</code>


### PR DESCRIPTION
also removing the `link:` prefix from `README.rdoc` because it caused the url on http://www.hawkular.org/hawkular-client-ruby/docs/latest/ page to look like this:

`http://www.hawkular.org/www.hawkular.org/hawkular-client-ruby/docs/latest/file.api_breaking_changes.html`

which obviously doesn't work