### PR TITLE
[gh-pages] Adding simple css file

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,13 @@
+body {
+  font-family: "Lucida Sans", "Lucida Grande", Verdana, Arial, sans-serif;
+  font-size: 20px;
+}
+
+a {
+  text-decoration: none;
+  color: #05a;
+}
+
+a:hover {
+  background: #ffffa5;
+}

--- a/docs/3.0.1/index.html
+++ b/docs/3.0.1/index.html
@@ -80,7 +80,7 @@ href="http://www.hawkular.org/hawkular-client-ruby/docs/">Documentation</a></p>
 <p>See <a
 href="http://www.hawkular.org/hawkular-client-ruby/docs/latest/file.CHANGES.html">CHANGELOG</a>
 for a list of changes and <a
-href="http:/www.hawkular.org/hawkular-client-ruby/docs/latest/file.api_breaking_changes.html">API-Breaking-Changes</a>
+href="http://www.hawkular.org/hawkular-client-ruby/docs/latest/file.api_breaking_changes.html">API-Breaking-Changes</a>
 for a list of api-breaking changes.</p>
 
 <h2 id="label-Overview">Overview</h2>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,6 +3,7 @@
     <title>
       Hawkular Ruby Client Documentation
     </title>
+    <link rel="stylesheet" href="css/style.css" type="text/css" charset="utf-8" />
   </head>
   <body>
     <h1>Available versions of documentation</h1>


### PR DESCRIPTION
..to make the index.html looking similar as the generated documentation. The colors are taken from the generated docs, unfortunately I can't use the whole css it generates, because the layout is broken.


NOTE: this PR does not target the `master` branch, but the `gh-pages`