### PR TITLE
Adds a timeout to wait_for_services script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ env:
 services:
   - docker
 before_install:
-  - (test $RUN_ON_LIVE_SERVER = 1 && ./.travis/start_hawkular_services.sh -d && ./.travis/wait_for_services.rb) || echo "Skipping live server"
+  - (test $RUN_ON_LIVE_SERVER = 1 && ./.travis/start_hawkular_services.sh && ./.travis/wait_for_services.rb) || (test $RUN_ON_LIVE_SERVER = 0  && echo "Skipping live server")
 after_success:
   - ./.travis.docs.rb

--- a/.travis/wait_for_services.rb
+++ b/.travis/wait_for_services.rb
@@ -21,6 +21,10 @@ services = {
   }
 }
 
+wait_time = 5
+max_attempts = 30
+
+attempt = 0
 services.each do |name, service|
   loop do
     uri = URI(service[:url])
@@ -31,7 +35,13 @@ services.each do |name, service|
     rescue
       puts 'Waiting for Hawkular-Services to accept connections'
     end
-    sleep 5
+    if attempt < max_attempts
+      sleep wait_time
+      attempt += 1
+    else
+      puts "Can't connect to [#{name}] using url [#{service[:url]}] after [#{attempt}] attemps"
+      exit 1
+    end
   end
 end
 puts 'Waiting 2 minutes for agent to complete it\'s first round...'


### PR DESCRIPTION
To avoid 'waiting-for-services' to hang waiting.

Next step would be to use error code of waiting-for-services on hawkular-services build script to avoid failing if stuck on waiting-for-services