### PR TITLE
Escaping feed_id before using it in list_metric_types

### DIFF
--- a/lib/hawkular/inventory/inventory_api.rb
+++ b/lib/hawkular/inventory/inventory_api.rb
@@ -204,7 +204,7 @@ module Hawkular::Inventory
       to_filter = []
       if (raw_hash.key? 'children') && (raw_hash['children'].key? 'metric') && !raw_hash['children']['metric'].empty?
         # Need to merge metric type info that we must grab from another place
-        metric_types = list_metric_types(path.feed_id)
+        metric_types = list_metric_types(URI.unescape(path.feed_id))
         metric_types_index = {}
         metric_types.each { |mt| metric_types_index[mt.path] = mt }
         to_filter = raw_hash['children']['metric'].map do |m|


### PR DESCRIPTION
list_metric_types assumes that the received feed_id is unescaped and
escapes it to form a CanonicalPath. Because the passed feed_id comes
from a CanonicalPath, it is already escaped and must be unescaped to
avoid double unescaping it.

NOTE: This should be released as 3.0.2. It is causing an error in MiQ.