### PR TITLE
Error name format unification

### DIFF
--- a/CHANGES.rdoc
+++ b/CHANGES.rdoc
@@ -4,6 +4,10 @@ This document describes the relevant changes between releases of the
 _hawkular-client_ project.
 
 
+=== v 3.0.3
+* Standardized Exceptions under the Hawkular namespace, and the old names were deprecated, here is the list:
+1. <code>Hawkular::BaseClient::HawkularException</code> -> <code>Hawkular::Exception</code>
+2. <code>Hawkular::BaseClient::HawkularConnectionException</code> -> <code>Hawkular::ConnectionException</code>
 === v 3.0.2
 * Adding <code>URI.unescape</code> in the <code>list_metrics_for_resource</code> method to fix the behavior of the method
 

--- a/CHANGES.rdoc
+++ b/CHANGES.rdoc
@@ -4,10 +4,11 @@ This document describes the relevant changes between releases of the
 _hawkular-client_ project.
 
 
-=== v 3.0.3
+=== v 4.0.0
 * Standardized Exceptions under the Hawkular namespace, and the old names were deprecated, here is the list:
-1. <code>Hawkular::BaseClient::HawkularException</code> -> <code>Hawkular::Exception</code>
-2. <code>Hawkular::BaseClient::HawkularConnectionException</code> -> <code>Hawkular::ConnectionException</code>
+  1. <code>Hawkular::BaseClient::HawkularException</code> -> <code>Hawkular::Exception</code>
+  2. <code>Hawkular::BaseClient::HawkularConnectionException</code> -> <code>Hawkular::ConnectionException</code>
+
 === v 3.0.2
 * Adding <code>URI.unescape</code> in the <code>list_metrics_for_resource</code> method to fix the behavior of the method
 

--- a/api_breaking_changes.rdoc
+++ b/api_breaking_changes.rdoc
@@ -1,5 +1,10 @@
 == Breaking changes in the major releases
 
+=== 4.0.0
+* Standardized Exceptions under the Hawkular namespace, and the old names were deprecated, here is the list:
+  1. <code>Hawkular::BaseClient::HawkularException</code> -> <code>Hawkular::Exception</code>
+  2. <code>Hawkular::BaseClient::HawkularConnectionException</code> -> <code>Hawkular::ConnectionException</code>
+
 === 3.0.0
 
 * A lot of methods in the inventory client have been changed or removed, here is the list:

--- a/lib/hawkular/client_utils.rb
+++ b/lib/hawkular/client_utils.rb
@@ -11,7 +11,10 @@ module Hawkular
     attr_reader :message, :status_code
   end
 
-  class ConnectionException < Exception
+  class ConnectionException < Hawkular::Exception
+  end
+
+  class ArgumentError < Hawkular::Exception
   end
 
   module ClientUtils

--- a/lib/hawkular/client_utils.rb
+++ b/lib/hawkular/client_utils.rb
@@ -1,4 +1,19 @@
 module Hawkular
+  # Specialized exception to be thrown
+  # when the interaction with Hawkular fails
+  class Exception < StandardError
+    def initialize(message, status_code = 0)
+      @message = message
+      @status_code = status_code
+      super(message)
+    end
+
+    attr_reader :message, :status_code
+  end
+
+  class ConnectionException < Exception
+  end
+
   module ClientUtils
     # Escapes the passed url part. This is necessary,
     # as many ids inside Hawkular can contain characters

--- a/lib/hawkular/hawkular_client.rb
+++ b/lib/hawkular/hawkular_client.rb
@@ -12,7 +12,9 @@ module Hawkular
     def initialize(hash)
       hash[:credentials] ||= {}
       hash[:options] ||= {}
-      fail 'no parameter ":entrypoint" given' if hash[:entrypoint].nil?
+
+      fail Hawkular::ArgumentError, 'no parameter ":entrypoint" given' if hash[:entrypoint].nil?
+
       @state = hash
     end
 
@@ -24,7 +26,7 @@ module Hawkular
                         when /^operations_/ then operations
                         when /^tokens_/ then tokens
                         else
-                          fail "unknown method prefix `#{name}`, allowed prefixes:"\
+                          fail Hawkular::ArgumentError, "unknown method prefix `#{name}`, allowed prefixes:"\
       '`inventory_`, `metrics_`,`alerts_`,`operations_`, `tokens_`'
                         end
       method = name.to_s.sub(/^[^_]+_/, '')

--- a/lib/hawkular/inventory/entities.rb
+++ b/lib/hawkular/inventory/entities.rb
@@ -181,7 +181,8 @@ module Hawkular::Inventory
     end
 
     def self.parse(path)
-      fail 'CanonicalPath must not be nil or empty' if path.to_s.strip.length == 0
+      fail Hawkular::ArgumentError, 'CanonicalPath must not be nil or empty' if path.to_s.strip.length == 0
+
       CanonicalPath.new(path_to_h path)
     end
 
@@ -257,7 +258,8 @@ module Hawkular::Inventory
     end
 
     def to_tags
-      fail 'Missing feed_id' if @feed_id.nil?
+      fail Hawkular::ArgumentError, 'Missing feed_id' if @feed_id.nil?
+
       tags = "module:inventory,feed:#{Regexp.quote(@feed_id)}"
       tags += ",type:rt,id:#{Regexp.quote(@resource_type_id)}" if @resource_type_id
       tags += ",type:mt,id:#{Regexp.quote(@metric_type_id)}" if @metric_type_id

--- a/lib/hawkular/metrics/metrics_client.rb
+++ b/lib/hawkular/metrics/metrics_client.rb
@@ -35,11 +35,12 @@ module Hawkular::Metrics
 
     def check_version
       version_status_hash = fetch_version_and_status
+
       fail_version_msg = 'Unable to determine implementation version for metrics'
-      fail fail_version_msg if version_status_hash['Implementation-Version'].nil?
+      fail Hawkular::Exception, fail_version_msg if version_status_hash['Implementation-Version'].nil?
       version = version_status_hash['Implementation-Version']
       major, minor = version.scan(/\d+/).map(&:to_i)
-      fail fail_version_msg if major.nil? || minor.nil?
+      fail Hawkular::Exception, fail_version_msg if major.nil? || minor.nil?
       @legacy_api = (major == 0 && minor < 16)
     end
 

--- a/spec/integration/hawkular_client_spec.rb
+++ b/spec/integration/hawkular_client_spec.rb
@@ -50,8 +50,8 @@ module Hawkular::Client::RSpec
     end
 
     it 'Should fail when calling method with unknown prefix' do
-      expect { @hawkular_client.ynventori_list_feeds }.to raise_error(RuntimeError)
-      expect { @hawkular_client.list_feeds }.to raise_error(RuntimeError)
+      expect { @hawkular_client.ynventori_list_feeds }.to raise_error(Hawkular::ArgumentError)
+      expect { @hawkular_client.list_feeds }.to raise_error(Hawkular::ArgumentError)
     end
 
     it 'Should fail when calling unknown method with known client prefix' do

--- a/spec/integration/operations_spec.rb
+++ b/spec/integration/operations_spec.rb
@@ -131,7 +131,7 @@ module Hawkular::Operations::RSpec
 
         it 'should bail with hash property error because no callback at all' do
           noop = { operationName: 'noop' }
-          expect { client.invoke_generic_operation(noop) }.to raise_error(ArgumentError,
+          expect { client.invoke_generic_operation(noop) }.to raise_error(Hawkular::ArgumentError,
                                                                           'You need to specify error callback')
         end
 
@@ -143,13 +143,13 @@ module Hawkular::Operations::RSpec
                 fail 'This should have failed'
               end
             end
-          end.to raise_error(ArgumentError, 'You need to specify error callback')
+          end.to raise_error(Hawkular::ArgumentError, 'You need to specify error callback')
         end
 
         it 'should bail with no host' do
           expect do
             Client.new(options.merge host: nil)
-          end.to raise_error(StandardError, 'no parameter ":host" or ":entrypoint" given')
+          end.to raise_error(Hawkular::ArgumentError, 'no parameter ":host" or ":entrypoint" given')
         end
       end
 

--- a/spec/integration/tokens_spec.rb
+++ b/spec/integration/tokens_spec.rb
@@ -29,7 +29,7 @@ module Hawkular::Token::RSpec
       begin
         client.create_token(creds)
         fail 'Should have failed with 401'
-      rescue Hawkular::BaseClient::HawkularException => exception
+      rescue Hawkular::Exception => exception
         expect(exception.status_code).to be(401)
       end
     end
@@ -41,7 +41,7 @@ module Hawkular::Token::RSpec
       begin
         client.create_token(creds)
         fail 'Should have failed with 401'
-      rescue Hawkular::BaseClient::HawkularException => exception
+      rescue Hawkular::Exception => exception
         expect(exception.status_code).to be(401)
       end
     end

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -168,7 +168,8 @@ describe 'Base Spec' do
     ret = c.normalize_entrypoint_url 'https://localhost:8080/', 'hawkular/alerts'
     expect(ret).to eq('https://localhost:8080/hawkular/alerts')
 
-    expect { c.normalize_entrypoint_url 'https://localhost:8080/hawkular/alerts', '' }.to raise_error(ArgumentError)
+    expect { c.normalize_entrypoint_url 'https://localhost:8080/hawkular/alerts', '' }
+      .to raise_error(Hawkular::ArgumentError)
 
     uri = URI.parse 'https://localhost:8080/'
     ret = c.normalize_entrypoint_url uri, 'hawkular/alerts'

--- a/spec/unit/canonical_path_spec.rb
+++ b/spec/unit/canonical_path_spec.rb
@@ -94,24 +94,24 @@ describe 'CanonicalPath' do
 
   # negative cases :(
   it 'with empty path cannot be parsed' do
-    expect { CanonicalPath.parse(nil) }.to raise_error(RuntimeError)
-    expect { CanonicalPath.parse('') }.to raise_error(RuntimeError)
-    expect { CanonicalPath.parse(' ') }.to raise_error(RuntimeError)
+    expect { CanonicalPath.parse(nil) }.to raise_error(Hawkular::ArgumentError)
+    expect { CanonicalPath.parse('') }.to raise_error(Hawkular::ArgumentError)
+    expect { CanonicalPath.parse(' ') }.to raise_error(Hawkular::ArgumentError)
   end
 
   context 'with no tenant id' do
     xit 'should not be parseable' do
-      expect { CanonicalPath.parse('/f;myFeed/rt;resType') }.to raise_error(RuntimeError)
+      expect { CanonicalPath.parse('/f;myFeed/rt;resType') }.to raise_error(Hawkular::ArgumentError)
     end
 
     xit 'should not be constructed' do
-      expect { CanonicalPath.new(feed_id: 'something') }.to raise_error(RuntimeError)
+      expect { CanonicalPath.new(feed_id: 'something') }.to raise_error(Hawkular::ArgumentError)
     end
   end
 
   it 'with empty path cannot be parsed' do
-    expect { CanonicalPath.parse(nil) }.to raise_error(RuntimeError)
-    expect { CanonicalPath.parse('') }.to raise_error(RuntimeError)
-    expect { CanonicalPath.parse(' ') }.to raise_error(RuntimeError)
+    expect { CanonicalPath.parse(nil) }.to raise_error(Hawkular::ArgumentError)
+    expect { CanonicalPath.parse('') }.to raise_error(Hawkular::ArgumentError)
+    expect { CanonicalPath.parse(' ') }.to raise_error(Hawkular::ArgumentError)
   end
 end


### PR DESCRIPTION
Changes from `Hawkular::BaseClient::HawkularException` format to `Hawkular::Exception`, and also changes all errors thrown to be instances of `Hawkular::Exception`, so client code can rescue just one exception and capture all errors thrown by the gem.