### PR TITLE
Use ERB::Util.url_encode which also escapes '/'

### DIFF
--- a/lib/hawkular/base_client.rb
+++ b/lib/hawkular/base_client.rb
@@ -3,6 +3,7 @@ require 'addressable/uri'
 
 require 'hawkular/logger'
 require 'hawkular/client_utils'
+require 'erb'
 
 module Hawkular
   # This is the base functionality for all the clients,
@@ -38,6 +39,10 @@ module Hawkular
       @logger = Hawkular::Logger.new
 
       fail Hawkular::ArgumentError, 'You need to provide an entrypoint' if entrypoint.nil?
+    end
+
+    def url(url_format, *params)
+      url_format % params.map { |p| ERB::Util.url_encode(p) }
     end
 
     def http_get(suburl, headers = {})

--- a/lib/hawkular/inventory/inventory_api_v4.rb
+++ b/lib/hawkular/inventory/inventory_api_v4.rb
@@ -1,5 +1,4 @@
 require 'hawkular/base_client'
-require 'uri'
 
 require 'hawkular/inventory/entities_v4'
 
@@ -37,21 +36,21 @@ module Hawkular::InventoryV4
     # Get single resource by id
     # @return Resource the resource
     def resource(id)
-      hash = http_get("/resources/#{URI.escape(id)}")
+      hash = http_get(url('/resources/%s', id))
       Resource.new(hash)
     end
 
     # Get resource by id with its complete subtree
     # @return Resource the resource
     def resource_tree(id)
-      hash = http_get("/resources/#{URI.escape(id)}/tree")
+      hash = http_get(url('/resources/%s/tree', id))
       Resource.new(hash)
     end
 
     # Get childrens of a resource
     # @return Children of a resource
     def children_resources(parent_id)
-      http_get("/resources/#{parent_id}/children")['results'].map { |r| Resource.new(r) }
+      http_get(url('/resources/%s/children', parent_id))['results'].map { |r| Resource.new(r) }
     end
 
     # List root resources
@@ -65,7 +64,7 @@ module Hawkular::InventoryV4
     # @return [Array<Resource>] List of resources
     def resources_for_type(type)
       # FIXME: pagination => lazy-loaded list with ruby?
-      http_get("/resources?typeId=#{URI.escape(type)}")['results'].map { |r| Resource.new(r) }
+      http_get(url('/resources?typeId=', type))['results'].map { |r| Resource.new(r) }
     end
 
     # Return version and status information for the used version of Hawkular-Inventory

--- a/spec/unit/base_spec.rb
+++ b/spec/unit/base_spec.rb
@@ -255,3 +255,32 @@ describe 'Base Spec' do
     end
   end
 end
+
+describe 'Url builder' do
+  it 'Should encode simple url' do
+    expect(Hawkular::BaseClient.new('not-needed').url('resource/endpoint')).to eql('resource/endpoint')
+  end
+
+  it 'Should encode with one param' do
+    expect(Hawkular::BaseClient.new('not-needed').url('resource/%s', 5)).to eql('resource/5')
+  end
+
+  it 'Should work with booleans' do
+    expect(Hawkular::BaseClient.new('not-needed').url('resource/%s', true)).to eql('resource/true')
+  end
+
+  it 'Should work with symbols' do
+    expect(Hawkular::BaseClient.new('not-needed').url('abc/%s', :true)).to eql('abc/true')
+  end
+
+  it 'Should work with multiple params' do
+    expect(Hawkular::BaseClient.new('not-needed').url('resource/%s/inner/%s', true, :ok)).to eql(
+      'resource/true/inner/ok')
+  end
+
+  it 'Should work with & and ? params' do
+    expect(Hawkular::BaseClient.new('not-needed')
+    .url('resource/%s/stuff?myid=%s&this=that', 'super', '0&delete_everything=true'))
+      .to eql('resource/super/stuff?myid=0%26delete_everything%3Dtrue&this=that')
+  end
+end


### PR DESCRIPTION
 '/' is used on id's and isn't escaped by URI.escape.
 Maybe there is others that aren't handled and is the reason
 `client_utils.rb` was born.

We can't do the escaping on `http_get` unless we pass around the `params`, but we would need to replicate that to `http_post`, `http_put`, etc.
