### PR TITLE
[Hawkular-1259] Preparation to release version 5.0.0.pre1

### DIFF
--- a/CHANGES.rdoc
+++ b/CHANGES.rdoc
@@ -3,6 +3,20 @@
 This document describes the relevant changes between releases of the
 _hawkular-client_ project.
 
+=== v 5.0.0.pre1
+* Hawkular services version 0.40.x and Hawkular Agent 1.x will be the last
+  versions to include support for _inventory-on-metrics_ and Hawkular Metrics.
+  The following versions won't be backwards compatible. Right now, a new API
+  for inventory is already implemented. This pre-release of the client is
+  adding support for this new inventory API and removing all support for the
+  previous implementation. See link:api_breaking_changes.rdoc for more details.
+* Because of the new inventory implementation, the _Operations_ client requires
+  the feed id to be sent on all operations. See link:api_breaking_changes.rdoc
+  for more details.
+* Support for a _sender_request_id_ has been added to the _Operations_ client.
+  This allows to match operation requests with their respective operation result
+  websocket messages.
+
 === v 4.1.0
 * Fixed binary data handling when invoking <em>Export JDR</em> on operations API.
 * Added <em>delete_immediately</em> parameter to <em>Export JDR</em> operation.

--- a/api_breaking_changes.rdoc
+++ b/api_breaking_changes.rdoc
@@ -1,5 +1,27 @@
 == Breaking changes in the major releases
 
+=== 5.0.0.pre1
+* The Hawkular inventory implementation was rewritten. Thus, the support for
+  inventory on metrics has been removed from the client. The new API is now
+  being used. Some of the most important changes are these:
+  * CanonicalPath is removed. Now, entities in inventory have opaque IDs,
+    and no assumptions about the format of the ID can be done.
+  * Inventory has now four basic classes for entities: Resource, Resource Type,
+    Metric and Operation. The _BaseEntity_ class has been removed.
+  * The inventory client <code>Hawkular::Inventory::Client</code> class was
+    fully rewritten. None of the previous methods exist. Now, it is using the new
+    API exposed by Hawkular and provides basic methods to traverse the inventory
+    tree and do some simple queries.
+* Almost all _Operations_ client methods receive a hash with the parameters
+  to perform the operation. A common hash key was <code>resourcePath</code>.
+  Because of the new inventory API, this key is no longer requried. Instead,
+  <code>resourceId</code> and <code>feedId</code> keys are required. This means
+  that all methods of the _Operations_ client class are non-backwards compatible.
+  * In particular, <code>export_jdr</code> method does not receive a hash, but
+    plain parameters. The <code>resourcePath</code> parameter was replaced by
+    <code>resourceId</code> and <code>feedId</code> parameters. Also, support
+    for <code>sender_request_id</code> is added as a parameter.
+
 === 4.0.0
 * Standardized Exceptions under the Hawkular namespace, and the old names were deprecated, here is the list:
   1. <code>Hawkular::BaseClient::HawkularException</code> -> <code>Hawkular::Exception</code>

--- a/hawkularclient.gemspec
+++ b/hawkularclient.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/hawkular/hawkular-client-ruby'
   gem.summary       = 'A Ruby client for Hawkular'
   gem.license       = 'Apache-2.0'
-  gem.required_ruby_version = '>= 2.0.0'
+  gem.required_ruby_version = '>= 2.2.0'
   gem.description = <<-EOS
     A Ruby client for Hawkular
   EOS

--- a/lib/hawkular/version.rb
+++ b/lib/hawkular/version.rb
@@ -4,5 +4,5 @@
 # @see https://github.com/hawkular
 module Hawkular
   # Version of the Hawkular Ruby Gem
-  VERSION = '4.1.0'.freeze
+  VERSION = '5.0.0.pre1'.freeze
 end


### PR DESCRIPTION
* Describing high level changes in the version
* Describing breaking changes
* Bumping version in gemspec

5.0.0.pre1 will include [HAWKULAR-1259](https://issues.jboss.org/browse/HAWKULAR-1259) work.