### PR TITLE
Fix to_camel_case

### DIFF
--- a/lib/hawkular/operations/operations_api.rb
+++ b/lib/hawkular/operations/operations_api.rb
@@ -431,8 +431,14 @@ module Hawkular::Operations
     end
 
     def to_camel_case(str)
-      ret = str.split('_').collect(&:capitalize).join
-      ret[0, 1].downcase + ret[1..-1]
+      subs = str.split('_')
+      if subs.length > 1
+        ret = subs.collect(&:capitalize).join
+      else
+        ret = subs[0]
+      end
+      ret[0] = ret[0].downcase
+      ret
     end
   end
 end


### PR DESCRIPTION
Fix to_camel_case such that it does not downcase a param that is already camel case.