### PR TITLE
Return nil in "resource" method if requested resource doesn't exist

### DIFF
--- a/lib/hawkular/inventory/inventory_api.rb
+++ b/lib/hawkular/inventory/inventory_api.rb
@@ -39,6 +39,9 @@ module Hawkular::Inventory
     def resource(id)
       hash = http_get(url('/resources/%s', id))
       Resource.new(hash)
+    rescue ::Hawkular::Exception => e
+      return if e.cause.is_a?(::RestClient::NotFound)
+      raise
     end
 
     # Get resource by id with its complete subtree

--- a/spec/integration/inventory_spec.rb
+++ b/spec/integration/inventory_spec.rb
@@ -63,6 +63,10 @@ describe 'Inventory' do
     expect(heap_memory.labels).to include('area' => 'heap')
   end
 
+  it 'Returns nil if specified resource is not in inventory' do
+    expect(@client.resource('NonExistentResource')).to be_nil
+  end
+
   it 'Should get subtree' do
     id = @client.root_resources.find { |r| r.name == 'JMX [Local JMX][Runtime]' }.id
     res = @client.resource_tree(id)

--- a/spec/vcr_cassettes/Inventory/Templates/Returns_nil_if_specified_resource_is_not_in_inventory.yml
+++ b/spec/vcr_cassettes/Inventory/Templates/Returns_nil_if_specified_resource_is_not_in_inventory.yml
@@ -1,0 +1,50 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8080/hawkular/inventory/resources/NonExistentResource
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - identity
+      User-Agent:
+      - hawkular-client-ruby
+      Content-Type:
+      - application/json
+      Host:
+      - localhost:8080
+      Authorization:
+      - Basic amRvZTpwYXNzd29yZA==
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Expires:
+      - '0'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      X-Powered-By:
+      - Undertow/1
+      Server:
+      - WildFly/10
+      Pragma:
+      - no-cache
+      Date:
+      - Tue, 12 Dec 2017 20:18:44 GMT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '58'
+    body:
+      encoding: UTF-8
+      string: '{"errorMsg":"Resource id [NonExistentResource] not found"}'
+    http_version: 
+  recorded_at: Tue, 12 Dec 2017 20:18:44 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Method `resource` of inventory API is returning the generic
`Hawkular::Exception` if any error occurs. However, the special case of
querying non existent resources should be easily identifiable.

To accomplish this, a a nil value is returned if Hawkular replies with
404 status.