### PR TITLE
Allow for rest-client 2.1.0 to be used

### DIFF
--- a/hawkularclient.gemspec
+++ b/hawkularclient.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_runtime_dependency('addressable')
-  gem.add_runtime_dependency('rest-client', '~> 2.0.0')
+  gem.add_runtime_dependency('rest-client', '~> 2.0')
   gem.add_runtime_dependency('websocket-client-simple', '~> 0.3.0')
   gem.add_development_dependency('actionpack', '~> 4')
   gem.add_development_dependency('coveralls')

--- a/hawkularclient.gemspec
+++ b/hawkularclient.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_runtime_dependency('addressable')
-  gem.add_runtime_dependency('rest-client', '~> 2.0')
+  gem.add_runtime_dependency('rest-client', '~> 2.1')
   gem.add_runtime_dependency('websocket-client-simple', '~> 0.3.0')
   gem.add_development_dependency('actionpack', '~> 4')
   gem.add_development_dependency('coveralls')

--- a/spec/vcr_cassettes/Tokens/Should_be_able_to_create_a_new_token_for_an_actual_user.yml
+++ b/spec/vcr_cassettes/Tokens/Should_be_able_to_create_a_new_token_for_an_actual_user.yml
@@ -27,7 +27,7 @@ http_interactions:
       message: OK
     headers:
       Content-Encoding:
-      - gzip
+      - json
       Expires:
       - '0'
       Cache-Control:
@@ -48,8 +48,7 @@ http_interactions:
       - '227'
     body:
       encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAAI3Ny07DMBCF4VexvK6Rx576kh1iwxp1xW5sTyQrIUSJA1RV3x1X4gHYf+c/NznxVQ4yQgjeF1KA6BRGMiqkmBRCLhk9Ws4kT3LnvHHr/swJPKdgjNEha6utHUuKGDVQdD51u251yXWluXMTtHHJOhVGRoXW9jzmoM4GGbwlF9LYJz1Ojcvz48FocEobBe4CMEAYtH5y1r13dqzlP4x/1rrx/mDLMc8nSa1tNR2Ndznc5EIf3AOXz4kX8fcsviqJV/qejpk28Xakq3iZKy9N3u+/MwqPrisBAAA=
+      string: "{\"key\":\"918877da-1446-49a2-8b9b-41cdc4743eca\",\"secret\":\"5eb17eb822208c03033fdb94901a967b\",\"principal\":\"28026b36-8fe4-4332-84c8-524e173a68bf\",\"createdAt\":\"2016-02-16T11:18:00.636Z\",\"updatedAt\":\"2016-02-16T11:18:00.636Z\",\"expiresAt\":null,\"attributes\":{\"name\":\"Token created via Hawkular Ruby Client\"}}"
     http_version: 
   recorded_at: Tue, 16 Feb 2016 11:18:00 GMT
 recorded_with: VCR 3.0.1

--- a/spec/vcr_cassettes/Tokens/Should_be_able_to_list_the_available_tokens.yml
+++ b/spec/vcr_cassettes/Tokens/Should_be_able_to_list_the_available_tokens.yml
@@ -9,8 +9,6 @@ http_interactions:
     headers:
       Accept:
       - application/json
-      Accept-Encoding:
-      - gzip, deflate
       User-Agent:
       - rest-client/2.0.0.rc1 (linux-gnu x86_64) ruby/2.2.4p230
       Content-Type:
@@ -24,7 +22,7 @@ http_interactions:
       message: OK
     headers:
       Content-Encoding:
-      - gzip
+      - json
       Expires:
       - '0'
       Cache-Control:
@@ -45,8 +43,7 @@ http_interactions:
       - '22'
     body:
       encoding: ASCII-8BIT
-      string: !binary |-
-        H4sIAAAAAAAAAIuOBQApu0wNAgAAAA==
+      string: "[]"
     http_version: 
   recorded_at: Tue, 16 Feb 2016 11:18:00 GMT
 recorded_with: VCR 3.0.1


### PR DESCRIPTION
Relax the restriction on `rest-client ~> 2.0.0` so that v2.1.0 can be used while allowing existing callers to still use `v2.0.*` if they want.